### PR TITLE
pcn-k8switch: remove garbage in datapath file

### DIFF
--- a/src/services/pcn-k8switch/src/K8switch_dp.c
+++ b/src/services/pcn-k8switch/src/K8switch_dp.c
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-
-#pragma once
-
-#include <string>
-
 #include <uapi/linux/if_arp.h>
 #include <uapi/linux/ip.h>
 #include <uapi/linux/tcp.h>


### PR DESCRIPTION
Remove two garbage lines that are breaking pcn-k8s.