### PR TITLE
components/k8s: remove dockersecret

### DIFF
--- a/src/components/k8s/dockersecret.yaml
+++ b/src/components/k8s/dockersecret.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-metadata:
-  name: mvbdockersecret
-  namespace: kube-system
-data:
-  .dockercfg: eyJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOnsidXNlcm5hbWUiOiJtYXVyaWNpb3Zhc3F1ZXpiZXJuYWwiLCJwYXNzd29yZCI6Imlvdm5ldDc1MTQiLCJlbWFpbCI6Im1hdXJpY2lvdmFzcXVlemJlcm5hbEBnbWFpbC5jb20iLCJhdXRoIjoiYldGMWNtbGphVzkyWVhOeGRXVjZZbVZ5Ym1Gc09tbHZkbTVsZERjMU1UUT0ifX0=
-kind: Secret
-type: kubernetes.io/dockercfg
----

--- a/src/components/k8s/pcn-k8s.yaml
+++ b/src/components/k8s/pcn-k8s.yaml
@@ -192,8 +192,6 @@ spec:
           configMap:
             name: kube-proxy
             #namespace: kube-public
-      imagePullSecrets:
-      - name: mvbdockersecret
       tolerations:
       - effect: NoSchedule
         key: node.kubernetes.io/not-ready


### PR DESCRIPTION
Docker images are now public hence dockersecret is not needed anymore.
