### PR TITLE
pcn-iptables: cleanup old references to DDoS in HORUS

### DIFF
--- a/src/services/pcn-iptables/src/CMakeLists.txt
+++ b/src/services/pcn-iptables/src/CMakeLists.txt
@@ -37,7 +37,7 @@ load_file_as_variable(pcn-iptables datapaths/Iptables_ChainSelector_dp.c iptable
 load_file_as_variable(pcn-iptables datapaths/Iptables_ConntrackLabel_dp.c iptables_code_conntracklabel)
 load_file_as_variable(pcn-iptables datapaths/Iptables_ConntrackMatch_dp.c iptables_code_conntrackmatch)
 load_file_as_variable(pcn-iptables datapaths/Iptables_ConntrackTableUpdate_dp.c iptables_code_conntracktableupdate)
-load_file_as_variable(pcn-iptables datapaths/Iptables_Ddos_dp.c iptables_code_ddos)
+load_file_as_variable(pcn-iptables datapaths/Iptables_Horus_dp.c iptables_code_horus)
 load_file_as_variable(pcn-iptables datapaths/Iptables_IpLookup_dp.c iptables_code_iplookup)
 load_file_as_variable(pcn-iptables datapaths/Iptables_L4PortLookup_dp.c iptables_code_l4portlookup)
 load_file_as_variable(pcn-iptables datapaths/Iptables_L4ProtocolLookup_dp.c iptables_code_l4protolookup)

--- a/src/services/pcn-iptables/src/Chain.h
+++ b/src/services/pcn-iptables/src/Chain.h
@@ -126,11 +126,11 @@ class Chain : public ChainInterface {
           std::map<uint8_t, std::vector<uint64_t>> &statusMap,
           const std::vector<std::shared_ptr<ChainRule>> &rules);
 
-  static void ddosFromRulesToMap(
-          std::map<struct DdosRule, struct DdosValue> &ddos,
+  static void horusFromRulesToMap(
+          std::map<struct HorusRule, struct HorusValue> &horus,
           const std::vector<std::shared_ptr<ChainRule>> &rules);
 
-  static void fromRuleToDdosKeyValue(std::shared_ptr<ChainRule> rule,
-                                     struct DdosRule &key,
-                                     struct DdosValue &value);
+  static void fromRuleToHorusKeyValue(std::shared_ptr<ChainRule> rule,
+                                      struct HorusRule &key,
+                                      struct HorusValue &value);
 };

--- a/src/services/pcn-iptables/src/ChainStats.cpp
+++ b/src/services/pcn-iptables/src/ChainStats.cpp
@@ -149,20 +149,20 @@ void ChainStats::fetchCounters(const Chain &parent, const uint32_t &id,
     conntrackLabelProgram->flushCounters(parent.name, id);
   }
 
-  if (parent.parent_.ddos_mitigator_runtime_enabled_) {
-    if (!parent.parent_.ddos_mitigator_swap_) {
-      auto ddosProgram = dynamic_cast<Iptables::Ddos *>(programs[std::make_pair(
-          ModulesConstants::DDOS_INGRESS, ChainNameEnum::INVALID_INGRESS)]);
-      bytes += ddosProgram->getBytesCount(id);
-      pkts += ddosProgram->getPktsCount(id);
-      ddosProgram->flushCounters(id);
+  if (parent.parent_.horus_runtime_enabled_) {
+    if (!parent.parent_.horus_swap_) {
+      auto horusProgram = dynamic_cast<Iptables::Horus *>(programs[std::make_pair(
+          ModulesConstants::HORUS_INGRESS, ChainNameEnum::INVALID_INGRESS)]);
+      bytes += horusProgram->getBytesCount(id);
+      pkts += horusProgram->getPktsCount(id);
+      horusProgram->flushCounters(id);
     } else {
-      auto ddosProgram = dynamic_cast<Iptables::Ddos *>(
-          programs[std::make_pair(ModulesConstants::DDOS_INGRESS_SWAP,
+      auto horusProgram = dynamic_cast<Iptables::Horus *>(
+          programs[std::make_pair(ModulesConstants::HORUS_INGRESS_SWAP,
                                   ChainNameEnum::INVALID_INGRESS)]);
-      bytes += ddosProgram->getBytesCount(id);
-      pkts += ddosProgram->getPktsCount(id);
-      ddosProgram->flushCounters(id);
+      bytes += horusProgram->getBytesCount(id);
+      pkts += horusProgram->getPktsCount(id);
+      horusProgram->flushCounters(id);
     }
   }
 }

--- a/src/services/pcn-iptables/src/Iptables.h
+++ b/src/services/pcn-iptables/src/Iptables.h
@@ -195,12 +195,12 @@ class Iptables : public polycube::service::Cube<Ports>,
   // interactive mode
   bool interactive_ = true;
 
-  // ddos mitigator optimization enabled by current rule set
-  bool ddos_mitigator_runtime_enabled_ = false;
+  // HORUS optimization enabled by current rule set
+  bool horus_runtime_enabled_ = false;
   bool horus_enabled = false;
 
-  // are we on swap or regular ddosmitigator program index
-  bool ddos_mitigator_swap_ = false;
+  // are we on swap or regular horus program index
+  bool horus_swap_ = false;
 
   bool fib_lookup_enabled_;
   bool fib_lookup_set_ = false;
@@ -284,14 +284,14 @@ class Iptables : public polycube::service::Cube<Ports>,
     void updateLocalIps();
   };
 
-  class Ddos : public Program {
+  class Horus : public Program {
    public:
-    enum DdosType { DDOS_INGRESS, DDOS_EGRESS };
+    enum HorusType { HORUS_INGRESS, HORUS_EGRESS };
 
-    Ddos(const int &index, Iptables &outer,
-         const std::map<struct DdosRule, struct DdosValue> &ddos,
-         DdosType t = DDOS_INGRESS);
-    ~Ddos();
+    Horus(const int &index, Iptables &outer,
+         const std::map<struct HorusRule, struct HorusValue> &horus,
+         HorusType t = HORUS_INGRESS);
+    ~Horus();
 
     std::string getCode();
     std::string defaultActionString(ChainNameEnum chain);  // Overrides
@@ -300,12 +300,12 @@ class Iptables : public polycube::service::Cube<Ports>,
     uint64_t getBytesCount(int rule_number);
 
     void flushCounters(int rule_number);
-    void updateTableValue(struct DdosRule ddos_key, struct DdosValue ddos_value);
-    void updateMap(const std::map<struct DdosRule, struct DdosValue> &ddos);
+    void updateTableValue(struct HorusRule horus_key, struct HorusValue horus_value);
+    void updateMap(const std::map<struct HorusRule, struct HorusValue> &horus);
 
    private:
-    DdosType type_;
-    std::map<struct DdosRule, struct DdosValue> ddos_;
+    HorusType type_;
+    std::map<struct HorusRule, struct HorusValue> horus_;
   };
 
   class ChainSelector : public Program {

--- a/src/services/pcn-iptables/src/Utils.cpp
+++ b/src/services/pcn-iptables/src/Utils.cpp
@@ -479,16 +479,16 @@ bool Chain::portFromRulesToMap(
   return brk;
 }
 
-void Chain::fromRuleToDdosKeyValue(std::shared_ptr<ChainRule> rule,
-                                   struct DdosRule &key,
-                                   struct DdosValue &value) {
+void Chain::fromRuleToHorusKeyValue(std::shared_ptr<ChainRule> rule,
+                                    struct HorusRule &key,
+                                    struct HorusValue &value) {
   key.setFields = 0;
 
   try {
     IpAddr ips;
     ips.fromString(rule->getSrc());
     if (ips.netmask == 32) {
-      SET_BIT(key.setFields, DdosConst::SRCIP);
+      SET_BIT(key.setFields, HorusConst::SRCIP);
       key.src_ip = ips.ip;
     }
   } catch (std::runtime_error) {
@@ -498,7 +498,7 @@ void Chain::fromRuleToDdosKeyValue(std::shared_ptr<ChainRule> rule,
     IpAddr ipd;
     ipd.fromString(rule->getDst());
     if (ipd.netmask == 32) {
-      SET_BIT(key.setFields, DdosConst::DSTIP);
+      SET_BIT(key.setFields, HorusConst::DSTIP);
       key.dst_ip = ipd.ip;
     }
   } catch (std::runtime_error) {
@@ -506,21 +506,21 @@ void Chain::fromRuleToDdosKeyValue(std::shared_ptr<ChainRule> rule,
 
   try {
     uint8_t proto = Iptables::protocolFromStringToInt(rule->getL4proto());
-    SET_BIT(key.setFields, DdosConst::L4PROTO);
+    SET_BIT(key.setFields, HorusConst::L4PROTO);
     key.l4proto = proto;
   } catch (std::runtime_error) {
   }
 
   try {
     uint16_t srcport = rule->getSport();
-    SET_BIT(key.setFields, DdosConst::SRCPORT);
+    SET_BIT(key.setFields, HorusConst::SRCPORT);
     key.src_port = srcport;
   } catch (std::runtime_error) {
   }
 
   try {
     uint16_t dstport = rule->getDport();
-    SET_BIT(key.setFields, DdosConst::DSTPORT);
+    SET_BIT(key.setFields, HorusConst::DSTPORT);
     key.dst_port = dstport;
   } catch (std::runtime_error) {
   }
@@ -538,11 +538,11 @@ void Chain::fromRuleToDdosKeyValue(std::shared_ptr<ChainRule> rule,
   return;
 }
 
-void Chain::ddosFromRulesToMap(
-        std::map<struct DdosRule, struct DdosValue> &ddos,
+void Chain::horusFromRulesToMap(
+        std::map<struct HorusRule, struct HorusValue> &horus,
         const std::vector<std::shared_ptr<ChainRule>> &rules) {
-  struct DdosRule key;
-  struct DdosValue value;
+  struct HorusRule key;
+  struct HorusValue value;
 
   bool first_rule = true;
   uint64_t set_fields = 0;
@@ -553,7 +553,7 @@ void Chain::ddosFromRulesToMap(
 
   for (auto const &rule : rules) {
     i++;
-    fromRuleToDdosKeyValue(rule, key, value);
+    fromRuleToHorusKeyValue(rule, key, value);
 
     if (i == 1) {
       if (key.setFields == 0) {
@@ -567,7 +567,7 @@ void Chain::ddosFromRulesToMap(
       break;
     }
 
-    ddos.insert(std::pair<struct DdosRule, struct DdosValue>(key, value));
+    horus.insert(std::pair<struct HorusRule, struct HorusValue>(key, value));
   }
 }
 

--- a/src/services/pcn-iptables/src/datapaths/Iptables_Parser_dp.c
+++ b/src/services/pcn-iptables/src/datapaths/Iptables_Parser_dp.c
@@ -142,8 +142,8 @@ static int handle_rx(struct CTXTYPE *ctx, struct pkt_metadata *md) {
     pkt->dstPort = udp->dest;
   }
 
-#if _DDOS_ENABLED
-  call_bpf_program(ctx, _DDOS_MITIGATOR);
+#if _HORUS_ENABLED
+  call_bpf_program(ctx, _HORUS);
 #endif
 
   // or INGRESS or EGRESS

--- a/src/services/pcn-iptables/src/defines.h
+++ b/src/services/pcn-iptables/src/defines.h
@@ -44,8 +44,8 @@ const uint8_t CONNTRACKTABLEUPDATE_INGRESS = 4;
 const uint8_t CONNTRACKTABLEUPDATE_EGRESS = 4;
 
 // index of others modules
-const uint8_t DDOS_INGRESS = 5;
-const uint8_t DDOS_INGRESS_SWAP = 6;
+const uint8_t HORUS_INGRESS = 5;
+const uint8_t HORUS_INGRESS_SWAP = 6;
 
 // offset of modules in filtering pipeline
 const uint8_t CONNTRACKMATCH = 0;
@@ -106,26 +106,26 @@ struct IpAddr {
   }
 };
 
-// const used by ddos mitigator optimization
-namespace DdosConst {
+// const used by horus optimization
+namespace HorusConst {
 const uint8_t SRCIP = 0;
 const uint8_t DSTIP = 1;
 const uint8_t L4PROTO = 2;
 const uint8_t SRCPORT = 3;
 const uint8_t DSTPORT = 4;
 
-// apply DDoS mitigator optimization if there are at least # rules
+// apply Horus mitigator optimization if there are at least # rules
 // matching the pattern, at ruleset begin
-const uint8_t MIN_RULE_SIZE_FOR_DDOS = 1;
-const uint8_t MAX_RULE_SIZE_FOR_DDOS = -1;  // not used
+const uint8_t MIN_RULE_SIZE_FOR_HORUS = 1;
+const uint8_t MAX_RULE_SIZE_FOR_HORUS = -1;  // not used
 
-  // Enable DDoS optimization
-  // We want to disable DDoS Mitigator by default while we decide a policy to apply it or not.
+  // Enable Horus optimization
+  // We want to disable Horus by default while we decide a policy to apply it or not.
   // The problem of incompatibility is semantic, this function could break iptables compatibility in INPUT/FORWARD chain
-  // const uint8_t ENABLE_DDOS_MITIGATOR = 0;
+  // const uint8_t ENABLE_HORUS = 0;
 }
 
-struct DdosRule {
+struct HorusRule {
   uint32_t src_ip;
   uint32_t dst_ip;
   uint8_t l4proto;
@@ -134,7 +134,7 @@ struct DdosRule {
   // bitvector representing set fields for current rule
   uint64_t setFields;
 
-  bool operator<(const DdosRule &that) const {
+  bool operator<(const HorusRule &that) const {
     if (this->src_ip != that.src_ip)
       return (this->src_ip < that.src_ip);
     else if (this->dst_ip != that.dst_ip)
@@ -149,7 +149,7 @@ struct DdosRule {
   }
 } __attribute__((packed));
 
-struct DdosValue {
+struct HorusValue {
   uint8_t action;
   uint32_t ruleID;
 } __attribute__((packed));

--- a/src/services/pcn-iptables/src/modules/Parser.cpp
+++ b/src/services/pcn-iptables/src/modules/Parser.cpp
@@ -74,18 +74,18 @@ std::string Iptables::Parser::getCode() {
     replaceAll(no_macro_code, "call_bpf_program", "call_egress_program");
   }
 
-  if (iptables_.ddos_mitigator_runtime_enabled_) {
-    replaceAll(no_macro_code, "_DDOS_ENABLED", "1");
+  if (iptables_.horus_runtime_enabled_) {
+    replaceAll(no_macro_code, "_HORUS_ENABLED", "1");
   } else {
-    replaceAll(no_macro_code, "_DDOS_ENABLED", "0");
+    replaceAll(no_macro_code, "_HORUS_ENABLED", "0");
   }
 
-  if (iptables_.ddos_mitigator_swap_) {
-    replaceAll(no_macro_code, "_DDOS_MITIGATOR",
-               std::to_string(ModulesConstants::DDOS_INGRESS_SWAP));
+  if (iptables_.horus_swap_) {
+    replaceAll(no_macro_code, "_HORUS",
+               std::to_string(ModulesConstants::HORUS_INGRESS_SWAP));
   } else {
-    replaceAll(no_macro_code, "_DDOS_MITIGATOR",
-               std::to_string(ModulesConstants::DDOS_INGRESS));
+    replaceAll(no_macro_code, "_HORUS",
+               std::to_string(ModulesConstants::HORUS_INGRESS));
   }
 
   return no_macro_code;


### PR DESCRIPTION
this commit removes old references to ddos mitigator, that was the original name of the module used to implement HORUS optimization.