### PR TITLE
pcn-iptables: implement support for interface filtering (-i -o options)

### DIFF
--- a/src/services/pcn-iptables/src/CMakeLists.txt
+++ b/src/services/pcn-iptables/src/CMakeLists.txt
@@ -40,6 +40,7 @@ load_file_as_variable(pcn-iptables datapaths/Iptables_ConntrackTableUpdate_dp.c 
 load_file_as_variable(pcn-iptables datapaths/Iptables_Horus_dp.c iptables_code_horus)
 load_file_as_variable(pcn-iptables datapaths/Iptables_IpLookup_dp.c iptables_code_iplookup)
 load_file_as_variable(pcn-iptables datapaths/Iptables_L4PortLookup_dp.c iptables_code_l4portlookup)
+load_file_as_variable(pcn-iptables datapaths/Iptables_InterfaceLookup_dp.c iptables_code_interfacelookup)
 load_file_as_variable(pcn-iptables datapaths/Iptables_L4ProtocolLookup_dp.c iptables_code_l4protolookup)
 load_file_as_variable(pcn-iptables datapaths/Iptables_Parser_dp.c iptables_code_parser)
 load_file_as_variable(pcn-iptables datapaths/Iptables_TcpFlagsLookup_dp.c iptables_code_tcpflagslookup)

--- a/src/services/pcn-iptables/src/Chain.h
+++ b/src/services/pcn-iptables/src/Chain.h
@@ -118,6 +118,11 @@ class Chain : public ChainInterface {
           const uint8_t &type, std::map<uint16_t, std::vector<uint64_t>> &ports,
           const std::vector<std::shared_ptr<ChainRule>> &rules);
 
+  static bool interfaceFromRulesToMap(
+          const uint8_t &type, std::map<uint16_t, std::vector<uint64_t>> &interfaces,
+          const std::vector<std::shared_ptr<ChainRule>> &rules,
+          Iptables& iptables);
+
   static bool flagsFromRulesToMap(
           std::vector<std::vector<uint64_t>> &flags,
           const std::vector<std::shared_ptr<ChainRule>> &rules);

--- a/src/services/pcn-iptables/src/ChainRule.cpp
+++ b/src/services/pcn-iptables/src/ChainRule.cpp
@@ -63,6 +63,16 @@ void ChainRule::update(const ChainRuleJsonObject &conf) {
     l4Proto = protocolFromStringToInt(conf.getL4proto());
     l4ProtoIsSet = true;
   }
+  if (conf.inIfaceIsSet()) {
+    this->inIface = conf.getInIface();
+    parent_.parent_.interfaceNameToIndex(inIface);
+    inIfaceIsSet = true;
+  }
+  if (conf.outIfaceIsSet()) {
+    this->outIface = conf.getOutIface();
+    parent_.parent_.interfaceNameToIndex(outIface);
+    outIfaceIsSet = true;
+  }
   if (conf.actionIsSet()) {
     this->action = conf.getAction();
     actionIsSet = true;
@@ -426,10 +436,12 @@ void ChainRule::setDst(const std::string &value) {
       "new one.");
 }
 
-// TODO TO IMPLEMENT
 std::string ChainRule::getOutIface() {
   // This method retrieves the outIface value.
-  throw std::runtime_error("[ChainRule]: Method getOutIface not implemented");
+  if (!outIfaceIsSet) {
+    throw std::runtime_error("Out iface not set.");
+  }
+  return this->outIface;
 }
 
 void ChainRule::setOutIface(const std::string &value) {
@@ -470,10 +482,12 @@ void ChainRule::setTcpflags(const std::string &value) {
       "new one.");
 }
 
-// TODO TO IMPLEMENT
 std::string ChainRule::getInIface() {
   // This method retrieves the inIface value.
-  throw std::runtime_error("[ChainRule]: Method getInIface not implemented");
+  if (!inIfaceIsSet) {
+    throw std::runtime_error("Out iface not set.");
+  }
+  return this->inIface;
 }
 
 void ChainRule::setInIface(const std::string &value) {

--- a/src/services/pcn-iptables/src/ChainRule.h
+++ b/src/services/pcn-iptables/src/ChainRule.h
@@ -147,6 +147,12 @@ class ChainRule : public ChainRuleInterface {
   uint16_t dstPort;
   bool dstPortIsSet = false;
 
+  std::string inIface;
+  bool inIfaceIsSet = false;
+
+  std::string outIface;
+  bool outIfaceIsSet = false;
+
   int l4Proto;
   bool l4ProtoIsSet = false;
 

--- a/src/services/pcn-iptables/src/Iptables.cpp
+++ b/src/services/pcn-iptables/src/Iptables.cpp
@@ -487,3 +487,13 @@ bool Iptables::fibLookupEnabled() {
 
   return fib_lookup_enabled_;
 }
+
+uint16_t Iptables::interfaceNameToIndex(const std::string &interface_string) {
+  try {
+    auto p = get_port(interface_string);
+    int index = p->index();
+    return index;
+  } catch (std::exception) {
+    throw std::runtime_error("invalid interface name");
+  }
+}

--- a/src/services/pcn-iptables/src/Iptables.cpp
+++ b/src/services/pcn-iptables/src/Iptables.cpp
@@ -489,11 +489,7 @@ bool Iptables::fibLookupEnabled() {
 }
 
 uint16_t Iptables::interfaceNameToIndex(const std::string &interface_string) {
-  try {
-    auto p = get_port(interface_string);
-    int index = p->index();
-    return index;
-  } catch (std::exception) {
-    throw std::runtime_error("invalid interface name");
-  }
+  auto p = get_port(interface_string);
+  int index = p->index();
+  return index;
 }

--- a/src/services/pcn-iptables/src/Iptables.h
+++ b/src/services/pcn-iptables/src/Iptables.h
@@ -179,6 +179,8 @@ class Iptables : public polycube::service::Cube<Ports>,
 
   bool fibLookupEnabled();
 
+  uint16_t interfaceNameToIndex(const std::string &interface_string);
+
   /*==========================
    *ATTRIBUTES DECLARATION
    *==========================*/
@@ -421,6 +423,28 @@ class Iptables : public polycube::service::Cube<Ports>,
       bool wildcard_rule_;
       std::string wildcard_string_;
   };
+
+
+  class InterfaceLookup : public Program {
+  public:
+      InterfaceLookup(const int &index, const ChainNameEnum &chain,
+                   const int &type, Iptables &outer);
+      InterfaceLookup(const int &index, const ChainNameEnum &chain,
+                   const int &type, Iptables &outer,
+                   const std::map<uint16_t, std::vector<uint64_t>> &interfaces);
+
+      ~InterfaceLookup();
+      std::string getCode();
+
+      bool updateTableValue(uint16_t port, const std::vector<uint64_t> &value);
+      void updateMap(const std::map<uint16_t, std::vector<uint64_t>> &interfaces);
+
+  private:
+      int type_;  // IN or OUT
+      bool wildcard_rule_;
+      std::string wildcard_string_;
+  };
+
 
   class TcpFlagsLookup : public Program {
    public:

--- a/src/services/pcn-iptables/src/Utils.cpp
+++ b/src/services/pcn-iptables/src/Utils.cpp
@@ -432,7 +432,7 @@ bool Chain::transportProtoFromRulesToMap(
 bool Chain::portFromRulesToMap(
         const uint8_t &type, std::map<uint16_t, std::vector<uint64_t>> &ports,
         const std::vector<std::shared_ptr<ChainRule>> &rules) {
-  std::vector<uint16_t> dont_care_rules;
+  std::vector<uint32_t> dont_care_rules;
 
   uint32_t rule_id;
   uint16_t port;
@@ -483,7 +483,7 @@ bool Chain::interfaceFromRulesToMap(
         const uint8_t &type, std::map<uint16_t, std::vector<uint64_t>> &interfaces,
         const std::vector<std::shared_ptr<ChainRule>> &rules,
         Iptables& iptables) {
-  std::vector<uint16_t> dont_care_rules;
+  std::vector<uint32_t> dont_care_rules;
 
   uint32_t rule_id;
   uint16_t interface;

--- a/src/services/pcn-iptables/src/Utils.cpp
+++ b/src/services/pcn-iptables/src/Utils.cpp
@@ -479,6 +479,61 @@ bool Chain::portFromRulesToMap(
   return brk;
 }
 
+bool Chain::interfaceFromRulesToMap(
+        const uint8_t &type, std::map<uint16_t, std::vector<uint64_t>> &interfaces,
+        const std::vector<std::shared_ptr<ChainRule>> &rules,
+        Iptables& iptables) {
+  std::vector<uint16_t> dont_care_rules;
+
+  uint32_t rule_id;
+  uint16_t interface;
+
+  bool brk = true;
+
+  for (auto const &rule : rules) {
+    try {
+      rule_id = rule->getId();
+      interface = 0;
+      if (type == IN_TYPE) {
+        std::string interface_string = rule->getInIface();
+        interface = iptables.interfaceNameToIndex(interface_string);
+      } else {
+        std::string interface_string = rule->getOutIface();
+        interface = iptables.interfaceNameToIndex(interface_string);
+      }
+    } catch (std::runtime_error re) {
+      // Interface not set: don't care rule.
+      dont_care_rules.push_back(rule_id);
+      continue;
+    }
+
+    auto it = interfaces.find(interface);
+    if (it == interfaces.end()) {
+      // First entry
+      std::vector<uint64_t> bitVector(
+              FROM_NRULES_TO_NELEMENTS(Iptables::max_rules_));
+      SET_BIT(bitVector[rule_id / 63], rule_id % 63);
+      interfaces.insert(std::pair<uint16_t, std::vector<uint64_t>>(interface, bitVector));
+    } else {
+      SET_BIT((it->second)[rule_id / 63], rule_id % 63);
+    }
+  }
+  // Don't care rules are in all entries. Anyway, this loop is useless if there
+  // are no rules at all requiring matching on this field.
+  if (interfaces.size() != 0 && dont_care_rules.size() != 0) {
+    std::vector<uint64_t> bitVector(
+            FROM_NRULES_TO_NELEMENTS(Iptables::max_rules_));
+    interfaces.insert(std::pair<uint16_t, std::vector<uint64_t>>(0, bitVector));
+    for (auto const &ruleNumber : dont_care_rules) {
+      for (auto &interface : interfaces) {
+        SET_BIT((interface.second)[ruleNumber / 63], ruleNumber % 63);
+      }
+    }
+    brk = false;
+  }
+  return brk;
+}
+
 void Chain::fromRuleToHorusKeyValue(std::shared_ptr<ChainRule> rule,
                                     struct HorusRule &key,
                                     struct HorusValue &value) {

--- a/src/services/pcn-iptables/src/datapaths/Iptables_InterfaceLookup_dp.c
+++ b/src/services/pcn-iptables/src/datapaths/Iptables_InterfaceLookup_dp.c
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2019 The Polycube Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ==========================
+   Match on Interface IN/OUT.
+   ========================== */
+
+// _DIRECTION = {INPUT, FORWARD, OUTPUT}
+// _TYPE = {in, out}
+
+struct packetHeaders {
+  uint32_t srcIp;
+  uint32_t dstIp;
+  uint8_t l4proto;
+  uint16_t srcPort;
+  uint16_t dstPort;
+  uint8_t flags;
+  uint32_t seqN;
+  uint32_t ackN;
+  uint8_t connStatus;
+};
+
+// PERCPU ARRAY
+// with parsed headers for current packet
+BPF_TABLE("extern", int, struct packetHeaders, packet, 1);
+static __always_inline struct packetHeaders *getPacket() {
+  int key = 0;
+  return packet.lookup(&key);
+}
+
+#if _NR_ELEMENTS > 0
+struct elements {
+  uint64_t bits[_MAXRULES];
+};
+
+BPF_TABLE("extern", int, struct elements, sharedEle, 1);
+static __always_inline struct elements *getShared() {
+  int key = 0;
+  return sharedEle.lookup(&key);
+}
+
+BPF_HASH(_TYPEInterfaces_DIRECTION, uint16_t, struct elements);
+static __always_inline struct elements *getBitVect(uint16_t *key) {
+  return _TYPEInterfaces_DIRECTION.lookup(key);
+}
+#endif
+
+BPF_TABLE("extern", int, u64, pkts_default__DIRECTION, 1);
+BPF_TABLE("extern", int, u64, bytes_default__DIRECTION, 1);
+static __always_inline void incrementDefaultCounters_DIRECTION(u32 bytes) {
+  u64 *value;
+  int zero = 0;
+  value = pkts_default__DIRECTION.lookup(&zero);
+  if (value) {
+    *value += 1;
+  }
+
+  value = bytes_default__DIRECTION.lookup(&zero);
+  if (value) {
+    *value += bytes;
+  }
+}
+
+static int handle_rx(struct CTXTYPE *ctx, struct pkt_metadata *md) {
+
+#if _WILDCARD_RULE
+u64 wildcard_ele[_MAXRULES] = _WILDCARD_BITVECTOR;
+#endif
+
+/*The struct elements and the lookup table are defined only if _NR_ELEMENTS>0,
+ * so
+ * this code has to be used only in this case.*/
+#if _NR_ELEMENTS > 0
+  int key = 0;
+  struct packetHeaders *pkt = getPacket();
+  if (pkt == NULL) {
+    // Not possible
+    return RX_DROP;
+  }
+
+  // TODO check if we should not use htons here.
+  uint16_t _TYPEInterface = md->in_port;
+  pcn_log(ctx, LOG_DEBUG, "_TYPEInterface _DIRECTION - current index: %d ", _TYPEInterface);
+
+  // Interfaces are stored in an hashmap
+  // A. map[0] (if exists) contains wildcard match
+  // B. map[interface] (if some exists) contain interface matching
+
+  // if no match in A. and B.
+  // we assume current bitvector is 0x000000...
+  // also AND returns 0x0000...
+  // so we can apply DEFAULT action with no additional cost.
+
+  struct elements *result = getShared();
+
+  bool isAllZero = true;
+  if (result == NULL) {
+    /*Can't happen. The PERCPU is preallocated.*/
+    return RX_DROP;
+  } else {
+    struct elements *ele = getBitVect(&_TYPEInterface);
+
+    if (ele == NULL) {
+      // if lookup with interface fails, we have to
+      // a. verify if we have a wildcard key (0)
+      // b. if so, use to bitvector from wildcard key
+
+    #if _WILDCARD_RULE
+      pcn_log(ctx, LOG_DEBUG, "+WILDCARD RULE+");
+      goto WILDCARD;
+    #else
+      pcn_log(ctx, LOG_DEBUG, "No match. ");
+      incrementDefaultCounters_DIRECTION(md->packet_len);
+      _DEFAULTACTION
+    #endif
+    }
+
+  /*#pragma unroll does not accept a loop with a single iteration, so we need to
+  * distinguish cases to avoid a verifier error.*/
+  #if _NR_ELEMENTS == 1
+      (result->bits)[0] = (ele->bits)[0] & (result->bits)[0];
+      if (result->bits[0] != 0)  isAllZero = false;
+      goto NEXT;
+
+    #if _WILDCARD_RULE
+    WILDCARD:;
+      (result->bits)[0] = wildcard_ele[0] & (result->bits)[0];
+      if (result->bits[0] != 0)  isAllZero = false;
+    #endif
+  #else
+      int i = 0;
+  #pragma unroll
+      for (i = 0; i < _NR_ELEMENTS; ++i) {
+        (result->bits)[i] = (result->bits)[i] & (ele->bits)[i];
+        if (result->bits[i] != 0)  isAllZero = false;
+      }
+      goto NEXT;
+    #if _WILDCARD_RULE
+    WILDCARD:;
+  #pragma unroll
+      for (i = 0; i < _NR_ELEMENTS; ++i) {
+        (result->bits)[i] = wildcard_ele[i] & (result->bits)[i];
+        if (result->bits[i] != 0)  isAllZero = false;
+      }
+    #endif
+  #endif
+  }  // if result == NULL
+
+NEXT:;
+  if (isAllZero) {
+    pcn_log(ctx, LOG_DEBUG, "Bitvector is all zero. Break pipeline for _TYPEInterface _DIRECTION");
+    incrementDefaultCounters_DIRECTION(md->packet_len);
+    _DEFAULTACTION
+  }
+  call_bpf_program(ctx, _NEXT_HOP_1);
+#else
+  return RX_DROP;
+#endif
+
+  return RX_DROP;
+}

--- a/src/services/pcn-iptables/src/defines.h
+++ b/src/services/pcn-iptables/src/defines.h
@@ -23,7 +23,7 @@ using namespace polycube::service;
 namespace ModulesConstants {
 
 // # of modules for each filtering pipeline
-const uint8_t NR_MODULES = 9;
+const uint8_t NR_MODULES = 10;
 // # of initial modules, common across pipelines
 const uint8_t NR_INITIAL_MODULES = 7;
 
@@ -54,9 +54,10 @@ const uint8_t IPDESTINATION = 2;
 const uint8_t L4PROTO = 3;
 const uint8_t PORTSOURCE = 4;
 const uint8_t PORTDESTINATION = 5;
-const uint8_t TCPFLAGS = 6;
-const uint8_t BITSCAN = 7;
-const uint8_t ACTION = 8;
+const uint8_t INTERFACE = 6;
+const uint8_t TCPFLAGS = 7;
+const uint8_t BITSCAN = 8;
+const uint8_t ACTION = 9;
 }
 
 namespace ConntrackModes {
@@ -69,7 +70,7 @@ const uint8_t ON = 1;
 const uint8_t OFF = 2;
 }
 
-enum Type { SOURCE_TYPE = 0, DESTINATION_TYPE = 1, INVALID_TYPE = 2 };
+enum Type { SOURCE_TYPE = 0, DESTINATION_TYPE = 1, IN_TYPE = 2, OUT_TYPE = 3, INVALID_TYPE = 4 };
 typedef enum Type Type;
 enum ActionsInt { DROP_ACTION = 0, ACCEPT_ACTION = 1, INVALID_ACTION = 2 };
 typedef enum ActionsInt ActionsInt;

--- a/src/services/pcn-iptables/src/modules/InterfaceLookup.cpp
+++ b/src/services/pcn-iptables/src/modules/InterfaceLookup.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2019 The Polycube Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../Iptables.h"
+#include "datapaths/Iptables_InterfaceLookup_dp.h"
+
+Iptables::InterfaceLookup::InterfaceLookup(const int &index,
+                                     const ChainNameEnum &chain,
+                                     const int &type, Iptables &outer)
+    : Iptables::Program(iptables_code_interfacelookup, index, chain, outer,
+                        (chain == ChainNameEnum::OUTPUT)
+                            ? ProgramType::EGRESS
+                            : ProgramType::INGRESS) {
+  this->type_ = type;
+
+  wildcard_rule_ = false;
+  wildcard_string_ = "";
+
+  load();
+}
+
+Iptables::InterfaceLookup::InterfaceLookup(
+    const int &index, const ChainNameEnum &chain, const int &type,
+    Iptables &outer, const std::map<uint16_t, std::vector<uint64_t>> &ports)
+    : Iptables::Program(iptables_code_interfacelookup, index, chain, outer,
+                        (chain == ChainNameEnum::OUTPUT)
+                            ? ProgramType::EGRESS
+                            : ProgramType::INGRESS) {
+  this->type_ = type;
+
+  auto it = ports.find(0);
+  if (it == ports.end()) {
+    wildcard_rule_ = false;
+    wildcard_string_ = "";
+    // std::cout << "-- wildcard NO --+" << std::endl;
+  } else {
+    wildcard_rule_ = true;
+    wildcard_string_ = fromContainerToMapString(it->second.begin(),
+                                              it->second.end(), "{", "}", ",");
+    // std::cout << "-- wildcard YES --+" << std::endl;
+    // std::cout << wildcardString << std::endl;
+  }
+
+  load();
+}
+
+Iptables::InterfaceLookup::~InterfaceLookup() {}
+
+std::string Iptables::InterfaceLookup::getCode() {
+  std::string no_macro_code = code_;
+
+  /*Replacing the maximum number of rules*/
+  replaceAll(no_macro_code, "_MAXRULES",
+             std::to_string(FROM_NRULES_TO_NELEMENTS(iptables_.max_rules_)));
+
+  /*Replacing hops*/
+  replaceAll(no_macro_code, "_NEXT_HOP_1", std::to_string(index_ + 1));
+
+  /*Replacing nrElements*/
+  replaceAll(no_macro_code, "_NR_ELEMENTS",
+             std::to_string(FROM_NRULES_TO_NELEMENTS(
+                 iptables_.getChain(chain_)->getNrRules())));
+
+  /*Replacing direction suffix*/
+  if (chain_ == ChainNameEnum::INPUT)
+    replaceAll(no_macro_code, "_DIRECTION", "Input");
+  if (chain_ == ChainNameEnum::FORWARD)
+    replaceAll(no_macro_code, "_DIRECTION", "Forward");
+  if (chain_ == ChainNameEnum::OUTPUT)
+    replaceAll(no_macro_code, "_DIRECTION", "Output");
+
+  /*Replacing type*/
+  if (type_ == IN_TYPE)
+    replaceAll(no_macro_code, "_TYPE", "in");
+  else
+    replaceAll(no_macro_code, "_TYPE", "out");
+
+  /*Replacing the default action*/
+  replaceAll(no_macro_code, "_DEFAULTACTION", defaultActionString());
+
+  if (wildcard_rule_) {
+    replaceAll(no_macro_code, "_WILDCARD_RULE", std::to_string(1));
+    replaceAll(no_macro_code, "_WILDCARD_BITVECTOR", wildcard_string_);
+  } else {
+    replaceAll(no_macro_code, "_WILDCARD_RULE", std::to_string(0));
+  }
+
+  if (program_type_ == ProgramType::INGRESS) {
+    replaceAll(no_macro_code, "call_bpf_program", "call_ingress_program");
+  } else if (program_type_ == ProgramType::EGRESS) {
+    replaceAll(no_macro_code, "call_bpf_program", "call_egress_program");
+  }
+
+  return no_macro_code;
+}
+
+bool Iptables::InterfaceLookup::updateTableValue(
+    uint16_t port, const std::vector<uint64_t> &value) {
+  std::string table_name;
+
+  if (type_ == IN_TYPE) {
+    table_name += "in";
+  } else if (type_ == OUT_TYPE) {
+    table_name += "out";
+  } else {
+    return false;
+  }
+  table_name += "Interfaces";
+
+  if (chain_ == ChainNameEnum::INPUT)
+    table_name += "Input";
+  else if (chain_ == ChainNameEnum::FORWARD)
+    table_name += "Forward";
+  else if (chain_ == ChainNameEnum::OUTPUT)
+    table_name += "Output";
+  else
+    return false;
+  try {
+    std::lock_guard<std::mutex> guard(program_mutex_);
+    auto table = iptables_.get_raw_table(table_name, index_, program_type_);
+    table.set(&port, value.data());
+  } catch (...) {
+    return false;
+  }
+  return true;
+}
+
+void Iptables::InterfaceLookup::updateMap(
+    const std::map<uint16_t, std::vector<uint64_t>> &ports) {
+  for (auto ele : ports) {
+    // std::cout << "+ele.second (btv.size) " << ele.second.size() << std::endl;
+    // std::cout << "+FROM_NRULES_TO_NELEMENTS(iptables.max_rules_) : " <<
+    // FROM_NRULES_TO_NELEMENTS(iptables.max_rules_) << std::endl;
+
+    updateTableValue(ele.first, ele.second);
+  }
+}

--- a/src/services/pcn-iptables/test/local_test_interfaces1.sh
+++ b/src/services/pcn-iptables/test/local_test_interfaces1.sh
@@ -1,0 +1,105 @@
+
+source "${BASH_SOURCE%/*}/helpers.bash"
+
+#test forwarding chain between namespaces
+#test filters on input interfaces (-i)
+
+function iptablescleanup {
+    set +e
+    polycubectl iptables del pcn-iptables
+    sudo ip netns del ns1
+    sudo ip link del veth1
+    sudo ip netns del ns2
+    sudo ip link del veth2
+}
+trap iptablescleanup EXIT
+
+echo -e "\nTest $0 \n"
+set -e
+set -x
+
+launch_iptables
+
+enable_ip_forwarding
+
+#create ns
+for i in `seq 1 2`;
+do
+    sudo ip netns add ns${i}
+    sudo ip link add veth${i}_ type veth peer name veth${i}
+    sudo ip link set veth${i}_ netns ns${i}
+    sudo ip netns exec ns${i} ip link set dev veth${i}_ up
+    sudo ip link set dev veth${i} up
+
+    sudo ifconfig veth${i} 10.0.${i}.254/24 up
+
+    sudo ip netns exec ns${i} ifconfig veth${i}_ 10.0.${i}.1/24
+    sudo ip netns exec ns${i} sudo ip route add default via 10.0.${i}.254
+done
+
+sudo ip netns exec ns1 ping 10.0.2.1 -c 2 -W 2
+
+pcn-iptables -P INPUT DROP
+pcn-iptables -P OUTPUT DROP
+
+sudo ip netns exec ns1 ping 10.0.2.1 -c 2 -W 2
+
+# test -i on FORWARD chain
+
+pcn-iptables -P FORWARD DROP
+
+test_fail sudo ip netns exec ns1 ping 10.0.2.1 -c 2 -W 2
+
+pcn-iptables -A FORWARD -i veth1 -j ACCEPT
+
+test_fail sudo ip netns exec ns1 ping 10.0.2.1 -c 2 -W 2
+
+pcn-iptables -A FORWARD -i veth2 -j ACCEPT
+
+sudo ip netns exec ns1 ping 10.0.2.1 -c 2 -W 2
+
+pcn-iptables -D FORWARD -i veth1 -j ACCEPT
+
+test_fail sudo ip netns exec ns1 ping 10.0.2.1 -c 2 -W 2
+
+pcn-iptables -D FORWARD -i veth2 -j ACCEPT
+
+test_fail sudo ip netns exec ns1 ping 10.0.2.1 -c 2 -W 2
+
+pcn-iptables -P FORWARD ACCEPT
+
+sudo ip netns exec ns1 ping 10.0.2.1 -c 2 -W 2
+
+# test -i -o on INPUT/ OUTPUT chains
+
+# obtain default route interface, e.g. ens3
+iface=$(sudo ip route | grep default | awk '{print $5}')
+
+pcn-iptables -F FORWARD
+
+sudo ip netns exec ns1 ping 10.0.2.1 -c 2 -W 2
+
+pcn-iptables -P FORWARD DROP
+
+test_fail sudo ip netns exec ns1 ping 10.0.2.1 -c 2 -W 2
+
+pcn-iptables -P INPUT ACCEPT
+pcn-iptables -P OUTPUT ACCEPT
+
+ping $ip -c 2 -W 2
+
+pcn-iptables -A INPUT -i $iface -j DROP
+
+test_fail ping $ip -c 2 -W 2
+
+pcn-iptables -D INPUT -i $iface -j DROP
+
+ping $ip -c 2 -W 2
+
+pcn-iptables -A OUTPUT -o $iface -j DROP
+
+test_fail ping $ip -c 2 -W 2
+
+pcn-iptables -D OUTPUT -o $iface -j DROP
+
+ping $ip -c 2 -W 2


### PR DESCRIPTION
Please don't merge until https://github.com/polycube-network/iptables/pull/1 is merged.
After that, we can update submodule reference in this PR.

this commit introduces support for filtering packets on interfaces.
e.g.
pcn-iptables -A INPUT -i eth0 -d 10.0.0.1 -j DROP
pcn-iptables -A OUTPUT -o eth1 -j DROP
pcn-iptables -A FORWARD -i veth1 -j ACCEPT

limitations:
- on FORWARD chain only support for -i parameter.
Due to architecture of pcn-iptables, support -o parameter would require
to guess linux routing decision in INGRESS hook, or to extend EGRESS hook
to filter also packets already processed by FORWARD pipeline.