### PR TITLE
Add support for bpf_redirect_map in XDP Cubes

### DIFF
--- a/src/libs/polycube/include/polycube/services/cube_iface.h
+++ b/src/libs/polycube/include/polycube/services/cube_iface.h
@@ -63,7 +63,7 @@ public:
 
   virtual uint16_t get_index(ProgramType type) const = 0;
 
-  virtual void update_forwarding_table(int index, int value) = 0;
+  virtual void update_forwarding_table(int index, int value, bool is_netdev) = 0;
 
   virtual int get_table_fd(const std::string &table_name, int index,
                              ProgramType type) = 0;

--- a/src/polycubed/src/cube.h
+++ b/src/polycubed/src/cube.h
@@ -68,7 +68,8 @@ class Cube : public CubeIface {
                 const std::string &service_name,
                 PatchPanel &patch_panel_ingress_,
                 PatchPanel &patch_panel_egress_,
-                LogLevel level, CubeType type);
+                LogLevel level, CubeType type,
+                const std::string &master_code = "");
   virtual ~Cube();
 
   // It is not possible to copy nor assign nor move an cube.
@@ -87,7 +88,7 @@ class Cube : public CubeIface {
 
   CubeType get_type() const;
 
-  void update_forwarding_table(int index, int value);
+  virtual void update_forwarding_table(int index, int value, bool is_netdev);
 
   uint32_t get_id() const;
 

--- a/src/polycubed/src/cube_xdp.h
+++ b/src/polycubed/src/cube_xdp.h
@@ -55,6 +55,8 @@ class CubeXDP : public Cube {
   int load(ebpf::BPF &bpf, ProgramType type);
   void unload(ebpf::BPF &bpf, ProgramType type);
 
+  void update_forwarding_table(int index, int value, bool is_netdev) override;
+
   void do_unload(ebpf::BPF &bpf);
   int do_load(ebpf::BPF &bpf);
   void compileIngress(ebpf::BPF &bpf, const std::string &code);
@@ -62,6 +64,9 @@ class CubeXDP : public Cube {
 
   int attach_flags_;
 
+  std::unique_ptr<ebpf::BPFDevmapTable> xdp_devmap_;
+
+  static const std::string MASTER_CODE;
   static const std::string XDP_WRAPPERC;
   static const std::string XDP_HELPERS;
 };


### PR DESCRIPTION
This commit introduces the possibility to use the `bpf_redirect_map` helper for XDP programs. 
This helper has improved performance compared to the normal `bpf_redirect` function that is used for other programs.
It uses a new map called `BPF_DEVMAP` that contains a mapping between a virtual index (used internally by the `Cube` to indicate a specific port) and the `ifindex` of the physical interface connected to the `Cube` port.

This map can only be used for sending packets out on a netdev (either physical or virtual) but cannot be used for the Cube-to-Cube communication. 
The approach adopted here is to check the value in the `forward_chain_` map; if the value is 0 than there are no entries for that output port and the devmap is used.

This commit depends on the BCC PR https://github.com/polycube-network/bcc/pull/1, which adds a single line definition to the generic `BPF_TABLE`.