### PR TITLE
Improve simplebridge data plane performance

### DIFF
--- a/src/services/pcn-simplebridge/src/FdbEntry.h
+++ b/src/services/pcn-simplebridge/src/FdbEntry.h
@@ -27,7 +27,7 @@ class Fdb;
 
 /* definitions copied from datapath */
 struct fwd_entry {
-  uint64_t timestamp;
+  uint32_t timestamp;
   uint32_t port;
 } __attribute__((packed));
 
@@ -36,7 +36,7 @@ using namespace io::swagger::server::model;
 class FdbEntry : public FdbEntryInterface {
 public:
   FdbEntry(Fdb &parent, const FdbEntryJsonObject &conf);
-  FdbEntry(Fdb &parent, const std::string &address, uint64_t entry_age, uint32_t out_port);
+  FdbEntry(Fdb &parent, const std::string &address, uint32_t entry_age, uint32_t out_port);
   virtual ~FdbEntry();
 
   static void create(Fdb &parent, const std::string &address, const FdbEntryJsonObject &conf);
@@ -77,7 +77,7 @@ private:
 
   std::string address_;
   std::string port_name_;
-  uint64_t entry_age_;
+  uint32_t entry_age_;
   uint32_t port_no_;
 };
 

--- a/src/services/pcn-simplebridge/src/Simplebridge.h
+++ b/src/services/pcn-simplebridge/src/Simplebridge.h
@@ -25,6 +25,7 @@
 #include "polycube/services/utils.h"
 
 #include <spdlog/spdlog.h>
+#include <thread>
 
 #include "Fdb.h"
 #include "Ports.h"
@@ -95,6 +96,13 @@ public:
 private:
   std::unordered_map<std::string, Ports> ports_;
   std::shared_ptr<Fdb> fdb_ = nullptr;
+
+  void updateTimestamp();
+  void updateTimestampTimer();
+  void quitAndJoin();
+
+  std::thread timestamp_update_thread_;
+  std::atomic<bool> quit_thread_;
 
   void flood_packet(Port &port, PacketInMetadata &md, const std::vector<uint8_t> &packet);
   std::mutex ports_mutex_;

--- a/src/services/pcn-simplebridge/src/Simplebridge_dp.c
+++ b/src/services/pcn-simplebridge/src/Simplebridge_dp.c
@@ -32,17 +32,27 @@
 #define REASON_FLOODING 0x01
 
 struct fwd_entry {
-  u64 timestamp;
+  u32 timestamp;
   u32 port;
-} __attribute__((packed));
+} __attribute__((packed, aligned(8)));
 
 BPF_TABLE("hash", __be64, struct fwd_entry, fwdtable, 1024);
+BPF_TABLE("array", int, uint32_t, timestamp, 1);
 
 struct eth_hdr {
   __be64   dst:48;
   __be64   src:48;
   __be16   proto;
 } __attribute__((packed));
+
+static __always_inline u32 time_get_sec() {
+  int key = 0;
+  u32 *ts = timestamp.lookup(&key);
+  if (ts)
+    return *ts;
+
+  return 0;
+}
 
 static __always_inline
 int handle_rx(struct CTXTYPE *ctx, struct pkt_metadata *md) {
@@ -60,7 +70,7 @@ int handle_rx(struct CTXTYPE *ctx, struct pkt_metadata *md) {
 
   // LEARNING PHASE
   __be64 src_key = eth->src;
-  u64 now = bpf_ktime_get_ns();
+  u32 now = time_get_sec();
 
   struct fwd_entry e; // used to update the entry in the fdb
 
@@ -84,15 +94,7 @@ int handle_rx(struct CTXTYPE *ctx, struct pkt_metadata *md) {
   u64 timestamp = entry->timestamp;
 
   // Check if the entry is still valid (not too old)
-  // Warning: the bpf_ktime_get_ns() used before is not monotonic and it may return
-  //  a value that is older than a previously returned value. So, we have to add
-  //  the very strange check 'now < timestamp' to handle this special case
-  if (now < timestamp) {
-    pcn_log(ctx, LOG_TRACE, "Entry is valid (but 'now < timestamp'). FORWARDING");
-    goto FORWARD;
-  }
-
-  if ((now - timestamp) > FDB_TIMEOUT*1000000000ULL) {
+  if ((now - timestamp) > FDB_TIMEOUT) {
     pcn_log(ctx, LOG_TRACE, "Entry is too old. FLOODING");
     fwdtable.delete(&dst_mac);
     goto DO_FLOODING;


### PR DESCRIPTION
This PR introduces a huge performance increase in the `Simplebridge` service by removing some bottlenecks from the data path such as the call to the `bpf_ktime_get_ns` and the `bpf_map_update` used to update the timestamp.

In fact, after some tests, I discovered that this function introduces a huge performance degradation (more evident in the multi-core tests due the lock required by the update) while updating the value directly after the lookup does not impact on the overall performance.
With this commit, the multicore throughput (during forwarding) of the bridge increased from `3.5`Mpps (with 64byte packets) to `~11.5`Mpps (with XDP and the `redirect_map` changes proposed in the PR https://github.com/polycube-network/polycube/pull/52.