### PR TITLE
Revert "pcn-router: remove arp table entries when deleting a port"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,7 +2,6 @@ The following people, in alphabetical order, have either authored or signed
 off on commits in the Polycube repository:
 
   Aasif Shaikh                            aasif@shaikh.cc
-  Francesco Messina                       francescomessina92@hotmail.com
   Fulvio Risso                            fulvio.risso@polito.it
   Jianwen Pi                              jianwpi@gmail.com
   Matteo Bertrone                         m.bertrone@gmail.com
@@ -14,6 +13,7 @@ The following additional people are mentioned in commit logs as having provided
 helpful bug reports, suggestions or have otherwise provided value to the
 project:
 
+  Francesco Messina                       francescomessina92@hotmail.com
   Francesco Picciariello                  picciariello.francesco@gmail.com
   Giuseppe Saitta                         giuseppe.saitta01@gmail.com
   Ivano Cerrato                           8002onavi@gmail.com

--- a/src/services/pcn-router/src/Ports.cpp
+++ b/src/services/pcn-router/src/Ports.cpp
@@ -181,17 +181,6 @@ void Ports::removeEntry(Router &parent, const std::string &name) {
 
   auto router_port = parent.get_hash_table<uint16_t, r_port>("router_port");
 
-  // remove the ArpEntry from the datapath, for this port
-  auto arp_table = parent.get_hash_table<uint32_t, arp_entry>("arp_table");
-  auto arp_entries = arp_table.get_all();
-  for (auto &entry : arp_entries) {
-    auto key = entry.first;
-    auto value = entry.second;
-
-    if (port->index() == value.port)
-      arp_table.remove(key);
-  }
-
   // remove the port from the datapath
   uint16_t index = port->index();
   router_port.remove(index);


### PR DESCRIPTION
Reverts polycube-network/polycube#62

As per the description, only `pcn-router` related things must have been changed, but there's a slide in edit for AUTHORS file.
Re-create the PR after review and approval from @yslu and @frisso 