### PR TITLE
scripts/checkstyle: move shebang to first line

### DIFF
--- a/scripts/check-style.py
+++ b/scripts/check-style.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python
+
 # This script is based on https://github.com/Sarcasm/run-clang-format
 
-#!/usr/bin/env python
 """A wrapper script around clang-format, suitable for linting multiple files
 and to use for continuous integration.
 


### PR DESCRIPTION
I moved by mistake the shebang from the first line, so the script is not working now.