### PR TITLE
pcn-iptables: remove useless delete and use shared_ptr

### DIFF
--- a/src/services/pcn-iptables/src/ChainStats.cpp
+++ b/src/services/pcn-iptables/src/ChainStats.cpp
@@ -94,7 +94,8 @@ void ChainStats::removeEntry(Chain &parent, const uint32_t &id) {
 
 void ChainStats::fetchCounters(const Chain &parent, const uint32_t &id,
                                uint64_t &pkts, uint64_t &bytes) {
-  std::map<std::pair<uint8_t, ChainNameEnum>, Iptables::Program *> &programs =
+  std::map<std::pair<uint8_t, ChainNameEnum>,
+           std::shared_ptr<Iptables::Program>> &programs =
       parent.parent_.programs_;
 
   if (programs.find(std::make_pair(ModulesConstants::ACTION, parent.name)) ==
@@ -104,7 +105,7 @@ void ChainStats::fetchCounters(const Chain &parent, const uint32_t &id,
     return;
   }
 
-  auto actionProgram = dynamic_cast<Iptables::ActionLookup *>(
+  auto actionProgram = std::dynamic_pointer_cast<Iptables::ActionLookup>(
       programs[std::make_pair(ModulesConstants::ACTION, parent.name)]);
 
   bytes = actionProgram->getBytesCount(id);
@@ -115,7 +116,8 @@ void ChainStats::fetchCounters(const Chain &parent, const uint32_t &id,
     // if first rule and acceptEstablished optimization enabled for this chain
     // sum accept established optimization counters to first rule
 
-    std::map<std::pair<uint8_t, ChainNameEnum>, Iptables::Program *> &programs =
+    std::map<std::pair<uint8_t, ChainNameEnum>,
+             std::shared_ptr<Iptables::Program>> &programs =
         parent.parent_.programs_;
 
     uint8_t module = 0;
@@ -140,8 +142,9 @@ void ChainStats::fetchCounters(const Chain &parent, const uint32_t &id,
       module = ModulesConstants::CONNTRACKLABEL_EGRESS;
     }
 
-    auto conntrackLabelProgram = dynamic_cast<Iptables::ConntrackLabel *>(
-        programs[std::make_pair(module, chainnameenum)]);
+    auto conntrackLabelProgram =
+        std::dynamic_pointer_cast<Iptables::ConntrackLabel>(
+            programs[std::make_pair(module, chainnameenum)]);
 
     pkts += conntrackLabelProgram->getAcceptEstablishedPktsCount(parent.name);
     bytes += conntrackLabelProgram->getAcceptEstablishedBytesCount(parent.name);
@@ -151,14 +154,14 @@ void ChainStats::fetchCounters(const Chain &parent, const uint32_t &id,
 
   if (parent.parent_.horus_runtime_enabled_) {
     if (!parent.parent_.horus_swap_) {
-      auto horusProgram = dynamic_cast<Iptables::Horus *>(
+      auto horusProgram = std::dynamic_pointer_cast<Iptables::Horus>(
           programs[std::make_pair(ModulesConstants::HORUS_INGRESS,
                                   ChainNameEnum::INVALID_INGRESS)]);
       bytes += horusProgram->getBytesCount(id);
       pkts += horusProgram->getPktsCount(id);
       horusProgram->flushCounters(id);
     } else {
-      auto horusProgram = dynamic_cast<Iptables::Horus *>(
+      auto horusProgram = std::dynamic_pointer_cast<Iptables::Horus>(
           programs[std::make_pair(ModulesConstants::HORUS_INGRESS_SWAP,
                                   ChainNameEnum::INVALID_INGRESS)]);
       bytes += horusProgram->getBytesCount(id);
@@ -178,7 +181,8 @@ std::shared_ptr<ChainStats> ChainStats::getDefaultActionCounters(
 
   csj.setDesc("DEFAULT");
 
-  std::map<std::pair<uint8_t, ChainNameEnum>, Iptables::Program *> &programs =
+  std::map<std::pair<uint8_t, ChainNameEnum>,
+           std::shared_ptr<Iptables::Program>> &programs =
       parent.parent_.programs_;
 
   uint8_t module = 0;
@@ -197,8 +201,9 @@ std::shared_ptr<ChainStats> ChainStats::getDefaultActionCounters(
     module = ModulesConstants::CHAINSELECTOR_EGRESS;
   }
 
-  auto chainSelectorProgram = dynamic_cast<Iptables::ChainSelector *>(
-      programs[std::make_pair(module, chainnameenum)]);
+  auto chainSelectorProgram =
+      std::dynamic_pointer_cast<Iptables::ChainSelector>(
+          programs[std::make_pair(module, chainnameenum)]);
 
   csj.setPkts(chainSelectorProgram->getDefaultPktsCount(parent.name));
   csj.setBytes(chainSelectorProgram->getDefaultBytesCount(parent.name));

--- a/src/services/pcn-iptables/src/Iptables.cpp
+++ b/src/services/pcn-iptables/src/Iptables.cpp
@@ -135,11 +135,11 @@ Iptables::Iptables(const std::string name, const IptablesJsonObject &conf,
 }
 
 Iptables::~Iptables() {
-  Iptables::Program *pr =
+  std::shared_ptr<Iptables::Program> pr =
       programs_[std::make_pair(ModulesConstants::CONNTRACKTABLEUPDATE_INGRESS,
                                ChainNameEnum::INVALID_INGRESS)];
-  Iptables::ConntrackTableUpdate *ctu =
-      static_cast<Iptables::ConntrackTableUpdate *>(pr);
+  std::shared_ptr<Iptables::ConntrackTableUpdate> ctu =
+      std::dynamic_pointer_cast<Iptables::ConntrackTableUpdate>(pr);
   ctu->quitAndJoin();
 
   netlink_instance_iptables_.unregisterObserver(
@@ -151,7 +151,7 @@ Iptables::~Iptables() {
 
   // Delete all eBPF programs
   for (auto it = programs_.begin(); it != programs_.end(); ++it) {
-    delete it->second;
+    programs_.erase(it);
   }
 }
 

--- a/src/services/pcn-iptables/src/Iptables.h
+++ b/src/services/pcn-iptables/src/Iptables.h
@@ -225,7 +225,7 @@ class Iptables : public polycube::service::Cube<Ports>,
     // Program type (INGRESS/EGRESS Hook)
     ProgramType program_type_;
     // only used in chainforwarder
-    std::map<std::string, Program *> hops_;
+    std::map<std::string, std::shared_ptr<Program>> hops_;
 
     // The relationship between inner and outer must be explictly made in C++
     // in the costructor
@@ -269,7 +269,7 @@ class Iptables : public polycube::service::Cube<Ports>,
     // <_NEXT_HOP_<INPUT/FORWARD/OUTPUT>_<hop_number>
     // E.g. _NEXT_HOP_INPUT_1
     // used in chainforwarder
-    void updateHop(int hop_number, Program *hop,
+    void updateHop(int hop_number, std::shared_ptr<Program> hop,
                    ChainNameEnum hop_chain = ChainNameEnum::INVALID_INGRESS);
 
     Program *getHop(std::string hop_name);
@@ -521,7 +521,9 @@ class Iptables : public polycube::service::Cube<Ports>,
   // Keeps the mapping between an index and the eBPF program, represented as a
   // child of the Program class. The index is <ModulesConstants, Chain>
   // maintains table of programs
-  std::map<std::pair<uint8_t, ChainNameEnum>, Iptables::Program *> programs_;
+  std::map<std::pair<uint8_t, ChainNameEnum>,
+           std::shared_ptr<Iptables::Program>>
+      programs_;
 
   /*==========================
    *METHODS DECLARATION

--- a/src/services/pcn-iptables/src/SessionTable.cpp
+++ b/src/services/pcn-iptables/src/SessionTable.cpp
@@ -80,7 +80,7 @@ void SessionTable::removeEntry(Iptables &parent, const std::string &src,
 
 std::vector<std::shared_ptr<SessionTable>> SessionTable::get(Iptables &parent) {
   std::vector<std::pair<ct_k, ct_v>> connections =
-      dynamic_cast<Iptables::ConntrackLabel *>(
+      std::dynamic_pointer_cast<Iptables::ConntrackLabel>(
           parent.programs_[std::make_pair(
               ModulesConstants::CONNTRACKLABEL_INGRESS,
               ChainNameEnum::INVALID_INGRESS)])

--- a/src/services/pcn-iptables/src/modules/Program.cpp
+++ b/src/services/pcn-iptables/src/modules/Program.cpp
@@ -37,7 +37,7 @@ Iptables::Program::~Program() {
   }
 }
 
-void Iptables::Program::updateHop(int hop_number, Program *hop,
+void Iptables::Program::updateHop(int hop_number, std::shared_ptr<Program> hop,
                                   ChainNameEnum hop_chain) {
   std::string hop_name = "_NEXT_HOP_";
   if (hop_chain == ChainNameEnum::INPUT)


### PR DESCRIPTION
delete is not needed if erase is called.

this PR replaces also some pointers with smart pointers this allows a better memory handling, avoiding some racing condition.