### PR TITLE
pcn-lbdsr: fix ports creation

### DIFF
--- a/src/services/pcn-loadbalancer-dsr/src/Lbdsr.cpp
+++ b/src/services/pcn-loadbalancer-dsr/src/Lbdsr.cpp
@@ -160,11 +160,7 @@ bool Lbdsr::reloadCode() {
   return true;
 }
 
-void Lbdsr::setFrontendPort(std::string portName) {
-  auto p = get_port(portName);
-
-  int index = p->index();
-
+void Lbdsr::setFrontendPort(std::string portName, int index) {
   if (frontend_port_ != -1) {
     throw std::runtime_error("Frontend port already set");
   }
@@ -176,11 +172,7 @@ void Lbdsr::setFrontendPort(std::string portName) {
   reloadCode();
 }
 
-void Lbdsr::setBackendPort(std::string portName) {
-  auto p = get_port(portName);
-
-  int index = p->index();
-
+void Lbdsr::setBackendPort(std::string portName, int index) {
   if (backend_port_ != -1) {
     throw std::runtime_error("Backend port already set");
   }

--- a/src/services/pcn-loadbalancer-dsr/src/Lbdsr.h
+++ b/src/services/pcn-loadbalancer-dsr/src/Lbdsr.h
@@ -111,8 +111,8 @@ class Lbdsr : public polycube::service::Cube<Ports>, public LbdsrInterface {
   bool reloadCode();
 
   void rmPort(std::string portName);
-  void setFrontendPort(std::string portName);
-  void setBackendPort(std::string portName);
+  void setFrontendPort(std::string portName, int index);
+  void setBackendPort(std::string portName, int index);
   void rmFrontendPort(std::string portName);
   void rmBackendPort(std::string portName);
 

--- a/src/services/pcn-loadbalancer-dsr/src/Ports.cpp
+++ b/src/services/pcn-loadbalancer-dsr/src/Ports.cpp
@@ -33,11 +33,11 @@ Ports::Ports(polycube::service::Cube<Ports> &parent,
 
   switch (port_type_) {
   case PortsTypeEnum::FRONTEND:
-    parent_.setFrontendPort(port->name());
+    parent_.setFrontendPort(port->name(), this->index());
     break;
 
   case PortsTypeEnum::BACKEND:
-    parent_.setBackendPort(port->name());
+    parent_.setBackendPort(port->name(), this->index());
     break;
   }
 


### PR DESCRIPTION
```
$polycubectl lbdsr lb1 ports add frontend-port type=FRONTEND
Port frontend-port does not exist
```
port creation was failing due to a bad port access in the code.
passing directly the index of the created port to `setFrontendPort()` solves the issue.