### PR TITLE
pcn-firewall: fix id initialize for default rule

### DIFF
--- a/src/services/pcn-firewall/src/ChainRule.cpp
+++ b/src/services/pcn-firewall/src/ChainRule.cpp
@@ -26,6 +26,7 @@ ChainRule::ChainRule(Chain &parent, const ChainRuleJsonObject &conf)
 ChainRule::~ChainRule() {}
 
 void ChainRule::update(const ChainRuleJsonObject &conf) {
+  id = conf.getId();
   if (conf.conntrackIsSet()) {
     if (!parent_.parent_.isContrackActive()) {
       throw new std::runtime_error(


### PR DESCRIPTION
This PR fixes a bad initialization of id in default rules statistics.