### PR TITLE
pcn-iptables: fix lsmod error message in docker

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,6 +81,7 @@ PACKAGES+=" libyang-dev"
 PACKAGES+=" autoconf libtool m4 automake"
 PACKAGES+=" libssl-dev" # needed for certificate based security
 PACKAGES+=" sudo" # needed for pcn-iptables, when building docker image
+PACKAGES+=" kmod" # needed for pcn-iptables, when using lsmod to unload conntrack if not needed
 
 if [ "$MODE" == "pcn-k8s" ]; then
   PACKAGES+=" curl" # needed for pcn-k8s to download a binary


### PR DESCRIPTION
avoid the error message when pcn-iptables try to unload conntrack module if not needed/required.