### PR TITLE
fix logging in services

### DIFF
--- a/src/libs/polycube/include/polycube/services/base_cube.h
+++ b/src/libs/polycube/include/polycube/services/base_cube.h
@@ -93,6 +93,7 @@ class BaseCube {
 
  protected:
   int get_table_fd(const std::string &table_name, int index, ProgramType type);
+  void set_control_plane_log_level(LogLevel level);
 
   std::shared_ptr<BaseCubeIface> cube_;  // pointer to the cube in polycubed
   log_msg_cb handle_log_msg;

--- a/src/libs/polycube/include/polycube/services/cube.h
+++ b/src/libs/polycube/include/polycube/services/cube.h
@@ -86,8 +86,10 @@ Cube<PortType>::Cube(const nlohmann::json &conf,
     packet_in(p, md_, packet);
   };
 
-  cube_ = factory_->create_cube(conf, ingress_code, egress_code, handle_log_msg,
-                                handle_packet_in);
+  cube_ = factory_->create_cube(
+      conf, ingress_code, egress_code, handle_log_msg,
+      std::bind(&Cube::set_control_plane_log_level, this, std::placeholders::_1),
+      handle_packet_in);
   // TODO: where to keep this reference?, keep a double reference?
   BaseCube::cube_ = cube_;
 }

--- a/src/libs/polycube/include/polycube/services/cube_factory.h
+++ b/src/libs/polycube/include/polycube/services/cube_factory.h
@@ -63,17 +63,21 @@ typedef std::function<void(const LogMsg *msg)> log_msg_cb;
 
 typedef std::function<void(void)> attach_cb;
 
+typedef std::function<void(LogLevel level)> set_log_level_cb;
+
 class CubeFactory {
  public:
   virtual std::shared_ptr<CubeIface> create_cube(
       const nlohmann::json &conf, const std::vector<std::string> &ingress_code,
       const std::vector<std::string> &egress_code, const log_msg_cb &log_msg,
+      const set_log_level_cb &log_level_cb,
       const packet_in_cb &cb = empty_packet_in_cb) = 0;
 
   virtual std::shared_ptr<TransparentCubeIface> create_transparent_cube(
       const nlohmann::json &conf, const std::vector<std::string> &ingress_code,
       const std::vector<std::string> &egress_code, const log_msg_cb &log_msg,
-      const packet_in_cb &cb, const attach_cb &attach) = 0;
+      const set_log_level_cb &log_level_cb, const packet_in_cb &cb,
+      const attach_cb &attach) = 0;
 
   virtual void destroy_cube(const std::string &name) = 0;
 };

--- a/src/libs/polycube/src/base_cube.cpp
+++ b/src/libs/polycube/src/base_cube.cpp
@@ -91,8 +91,12 @@ void BaseCube::datapath_log_msg(const LogMsg *msg) {
 }
 
 void BaseCube::set_log_level(LogLevel level) {
+  set_control_plane_log_level(level);
+  cube_->set_log_level(level);
+}
+
+void BaseCube::set_control_plane_log_level(LogLevel level) {
   logger()->set_level(logLevelToSPDLog(level));
-  return cube_->set_log_level(level);
 }
 
 LogLevel BaseCube::get_log_level() const {

--- a/src/libs/polycube/src/transparent_cube.cpp
+++ b/src/libs/polycube/src/transparent_cube.cpp
@@ -43,8 +43,10 @@ TransparentCube::TransparentCube(const nlohmann::json &conf,
   };
 
   cube_ = factory_->create_transparent_cube(
-      conf, ingress_code, egress_code, handle_log_msg, handle_packet_in,
-      std::bind(&TransparentCube::attach, this));
+      conf, ingress_code, egress_code, handle_log_msg,
+      std::bind(&TransparentCube::set_control_plane_log_level, this,
+                std::placeholders::_1),
+      handle_packet_in, std::bind(&TransparentCube::attach, this));
   // TODO: where to keep this reference?, keep a double reference?
   BaseCube::cube_ = cube_;
 }

--- a/src/polycubed/src/base_cube.cpp
+++ b/src/polycubed/src/base_cube.cpp
@@ -357,12 +357,19 @@ void BaseCube::set_log_level(LogLevel level) {
   if (level_ == level)
     return;
 
+  // change log level in dataplane
+  log_level_cb_(level);
+
   level_ = level;
   reload_all();
 }
 
 LogLevel BaseCube::get_log_level() const {
   return level_;
+}
+
+void BaseCube::set_log_level_cb(const polycube::service::set_log_level_cb &cb) {
+  log_level_cb_ = cb;
 }
 
 void BaseCube::set_conf(const nlohmann::json &conf) {

--- a/src/polycubed/src/base_cube.h
+++ b/src/polycubed/src/base_cube.h
@@ -19,6 +19,7 @@
 #include "bcc_mutex.h"
 #include "id_generator.h"
 #include "patchpanel.h"
+#include "polycube/services/cube_factory.h"
 #include "polycube/services/cube_iface.h"
 #include "polycube/services/guid.h"
 #include "polycube/services/json.hpp"
@@ -82,6 +83,8 @@ class BaseCube : virtual public BaseCubeIface {
   void set_conf(const nlohmann::json &conf);
   virtual nlohmann::json to_json() const;
 
+  void set_log_level_cb(const polycube::service::set_log_level_cb &cb);
+
  protected:
   static const int _POLYCUBE_MAX_BPF_PROGRAMS = 64;
   static const int _POLYCUBE_MAX_PORTS = 128;
@@ -136,6 +139,8 @@ class BaseCube : virtual public BaseCubeIface {
 
   void do_reload(const std::string &code, int index, ProgramType type);
   static IDGenerator id_generator_;
+
+  polycube::service::set_log_level_cb log_level_cb_;
 };
 
 }  // namespace polycubed

--- a/src/polycubed/src/cube_factory_impl.cpp
+++ b/src/polycubed/src/cube_factory_impl.cpp
@@ -39,13 +39,15 @@ CubeFactoryImpl::CubeFactoryImpl(const std::string &service_name)
 std::shared_ptr<CubeIface> CubeFactoryImpl::create_cube(
     const nlohmann::json &conf, const std::vector<std::string> &ingress_code,
     const std::vector<std::string> &egress_code, const log_msg_cb &log_msg,
-    const packet_in_cb &cb) {
+    const set_log_level_cb &log_level_cb, const packet_in_cb &cb) {
   auto name = conf.at("name").get<std::string>();
   auto type = string_to_cube_type(conf.at("type").get<std::string>());
   auto level = stringLogLevel(conf.at("loglevel").get<std::string>());
 
   auto cube =
       create_cube(name, ingress_code, egress_code, log_msg, type, cb, level);
+  auto base = std::dynamic_pointer_cast<BaseCube>(cube);
+  base->set_log_level_cb(log_level_cb);
   return std::move(cube);
 }
 
@@ -96,13 +98,16 @@ std::shared_ptr<CubeIface> CubeFactoryImpl::create_cube(
 std::shared_ptr<TransparentCubeIface> CubeFactoryImpl::create_transparent_cube(
     const nlohmann::json &conf, const std::vector<std::string> &ingress_code,
     const std::vector<std::string> &egress_code, const log_msg_cb &log_msg,
-    const packet_in_cb &cb, const attach_cb &attach) {
+    const set_log_level_cb &log_level_cb, const packet_in_cb &cb,
+    const attach_cb &attach) {
   auto name = conf.at("name").get<std::string>();
   auto type = string_to_cube_type(conf.at("type").get<std::string>());
   auto level = stringLogLevel(conf.at("loglevel").get<std::string>());
 
   auto cube = create_transparent_cube(name, ingress_code, egress_code, log_msg,
                                       type, cb, attach, level);
+  auto base = std::dynamic_pointer_cast<BaseCube>(cube);
+  base->set_log_level_cb(log_level_cb);
   return std::move(cube);
 }
 

--- a/src/polycubed/src/cube_factory_impl.h
+++ b/src/polycubed/src/cube_factory_impl.h
@@ -34,6 +34,7 @@ using service::TransparentCubeIface;
 using service::CubeFactory;
 using service::packet_in_cb;
 using service::log_msg_cb;
+using service::set_log_level_cb;
 using service::attach_cb;
 
 class CubeFactoryImpl : public CubeFactory {
@@ -44,12 +45,13 @@ class CubeFactoryImpl : public CubeFactory {
   std::shared_ptr<CubeIface> create_cube(
       const nlohmann::json &conf, const std::vector<std::string> &ingress_code,
       const std::vector<std::string> &egress_code, const log_msg_cb &log_msg,
-      const packet_in_cb &cb) override;
+      const set_log_level_cb &log_level_cb, const packet_in_cb &cb) override;
 
   std::shared_ptr<TransparentCubeIface> create_transparent_cube(
       const nlohmann::json &conf, const std::vector<std::string> &ingress_code,
       const std::vector<std::string> &egress_code, const log_msg_cb &log_msg,
-      const packet_in_cb &cb, const attach_cb &attach) override;
+      const set_log_level_cb &log_level_cb, const packet_in_cb &cb,
+      const attach_cb &attach) override;
 
   void destroy_cube(const std::string &name) override;
 


### PR DESCRIPTION
after 5a3e91ea90a2 ("implement base datamodel handling in polycubed") the
functionality to change the logging level of a cube was broken.  This because
the logging level was only being changed in the datapath but the control plane
logger (the actual logger that prints it to the terminal) wasn't being updated,
as a result some datapath logs messages were being lost.

This commit creates a new callback that is passed to the framework so when
the logging level is changed the cube is notified and it can update its logger.

Fixes: 5a3e91ea90a2 ("implement base datamodel handling in polycubed")

