### PR TITLE
fix build failure due to the following convertion:

### DIFF
--- a/src/polycubed/src/CMakeLists.txt
+++ b/src/polycubed/src/CMakeLists.txt
@@ -99,3 +99,4 @@ install (TARGETS polycubed DESTINATION bin)
 install(CODE
 "execute_process( COMMAND /bin/sh -c \"mkdir -p /var/log/polycube && chown $ENV{USER} /var/log/polycube \")")
 
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")


### PR DESCRIPTION
src/polycubed/src/rest_server.cpp:130:71: error: invalid conversion from ‘int (*)(int, void*)’ to ‘int (*)(int, X509_STORE_CTX*)