### PR TITLE
polycubed: fix list validation

### DIFF
--- a/src/polycubed/src/server/Resources/Body/ListResource.h
+++ b/src/polycubed/src/server/Resources/Body/ListResource.h
@@ -48,6 +48,16 @@ class ListResource : public virtual ParentResource {
   void SetDefaultIfMissing(nlohmann::json &body,
                            bool initialization) const final;
 
+  /*
+   * This function takes the keys (parsed from the url in "keys") and save
+   * them in the body of the request
+   */
+  void FillKeys(nlohmann::json &body, const ListKeyValues &keys);
+
+  std::vector<Response> BodyValidateMultiple(
+      const std::string &cube_name, const ListKeyValues &keys,
+      nlohmann::json &body, bool initialization) const;
+
   const std::vector<ListKey> keys_;
 
   nlohmann::json ToHelpJson() const override;

--- a/src/polycubed/src/server/Resources/Endpoint/ParentResource.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/ParentResource.cpp
@@ -105,6 +105,12 @@ void ParentResource::CreateReplaceUpdate(
   const auto &cube_name = Service::Cube(request);
   ListKeyValues keys{};
   Keys(request, keys);
+
+  // fill keys if they are missing
+  if (auto list = dynamic_cast<ListResource*>(this)) {
+    list->FillKeys(jbody, keys);
+  }
+
   auto body_errors = BodyValidate(cube_name, keys, jbody, initialization);
   errors.reserve(errors.size() + body_errors.size());
   std::move(std::begin(body_errors), std::end(body_errors),


### PR DESCRIPTION
The validation code for the list was not testing all the elements of the list,
it instead was testing the list as a container.  Due to this complex commands
issued with a rest client were failing, for instance:

```
curl -L -X POST --data '{"name":"hw0","ports":[{"name":"pippo"}]}' \
  "http://localhost:9000/polycube/v1/helloworld/hw0/"

curl -L -X POST --data \
  '[{"name":"toveth1", "peer":"veth1"}, {"name":"toveth2", "peer":"veth2"}]' \
  "http://localhost:9000/polycube/v1/helloworld/hw0/ports/
```

This commit implements a new logic that tests all the elements in a list, also
a new logic fill the keys in json body of a list request is added as well.

This failure was unnoticed because polycubectl does not allow to perform such
complex operations in a single command.

