### PR TITLE
Fix pcn k8s

### DIFF
--- a/src/polycubed/src/server/Resources/Body/ListResource.h
+++ b/src/polycubed/src/server/Resources/Body/ListResource.h
@@ -48,6 +48,16 @@ class ListResource : public virtual ParentResource {
   void SetDefaultIfMissing(nlohmann::json &body,
                            bool initialization) const final;
 
+  /*
+   * This function takes the keys (parsed from the url in "keys") and save
+   * them in the body of the request
+   */
+  void FillKeys(nlohmann::json &body, const ListKeyValues &keys);
+
+  std::vector<Response> BodyValidateMultiple(
+      const std::string &cube_name, const ListKeyValues &keys,
+      nlohmann::json &body, bool initialization) const;
+
   const std::vector<ListKey> keys_;
 
   nlohmann::json ToHelpJson() const override;

--- a/src/polycubed/src/server/Resources/Endpoint/ParentResource.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/ParentResource.cpp
@@ -105,6 +105,12 @@ void ParentResource::CreateReplaceUpdate(
   const auto &cube_name = Service::Cube(request);
   ListKeyValues keys{};
   Keys(request, keys);
+
+  // fill keys if they are missing
+  if (auto list = dynamic_cast<ListResource*>(this)) {
+    list->FillKeys(jbody, keys);
+  }
+
   auto body_errors = BodyValidate(cube_name, keys, jbody, initialization);
   errors.reserve(errors.size() + body_errors.size());
   std::move(std::begin(body_errors), std::end(body_errors),

--- a/src/services/pcn-k8sfilter/datamodel/k8sfilter.yang
+++ b/src/services/pcn-k8sfilter/datamodel/k8sfilter.yang
@@ -22,7 +22,8 @@ module k8sfilter {
           enum INTERNAL { description "Connected to LBRP"; }
         }
         mandatory true;
-        config false;
+        config true;
+        polycube-base:init-only-config;
         description "...";
       }
     }

--- a/src/services/pcn-k8switch/src/K8switch.cpp
+++ b/src/services/pcn-k8switch/src/K8switch.cpp
@@ -34,7 +34,7 @@ K8switch::K8switch(const std::string name, const K8switchJsonObject &conf)
   doSetVirtualClientSubnet(conf.getVirtualClientSubnet());
 
   // reload code a single time
-  reloadConfig();
+  add_program(getFlags() + k8switch_code, 0);
 
   addServiceList(conf.getService());
   addPortsList(conf.getPorts());
@@ -170,7 +170,7 @@ void K8switch::doSetVirtualClientSubnet(const std::string &value) {
   virtual_client_cidr_ = value;
 }
 
-void K8switch::reloadConfig() {
+std::string K8switch::getFlags() {
   std::string flags;
 
   // ports
@@ -197,6 +197,13 @@ void K8switch::reloadConfig() {
       "#define CLIENT_SUBNET " + std::to_string(htonl(client_subnet_)) + "\n";
   flags += "#define VIRTUAL_CLIENT_SUBNET " +
            std::to_string(htonl(virtual_client_subnet_)) + "\n";
+  logger()->debug("flags is {}", flags);
+
+  return flags;
+}
+
+void K8switch::reloadConfig() {
+  std::string flags(getFlags());
 
   logger()->debug("Reloading code with flags port: {}", flags);
 

--- a/src/services/pcn-k8switch/src/K8switch.h
+++ b/src/services/pcn-k8switch/src/K8switch.h
@@ -143,6 +143,7 @@ class K8switch : public polycube::service::Cube<Ports>,
   void cleanupSessionTable();
   uint32_t timestampToAge(const uint64_t timestamp);
   void tick();
+  std::string getFlags();
 
   std::unique_ptr<std::thread> tick_thread;
   bool stop_;


### PR DESCRIPTION
pcn-k8s was broken in few places:
- List validation was wrong and hence it was not possible to create a cube with the ports using a rest client
- k8switch had a bad logic to init the cube on construction time
- k8sfilter had a problem that prevented the creation of ports on this.

