### PR TITLE
polycubed: fix list autocompletion

### DIFF
--- a/src/polycubed/src/server/Resources/Endpoint/ListResource.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/ListResource.cpp
@@ -327,6 +327,7 @@ Response ListResource::Completion(const std::string &cube_name, HelpType type,
 
   auto size_keys = list_keys.size();
   std::string keyname = keys_[size_keys].Name();
+  std::string original_keyname = keys_[size_keys].OriginalName();
 
   nlohmann::json val = nlohmann::json::array();
 
@@ -349,7 +350,7 @@ Response ListResource::Completion(const std::string &cube_name, HelpType type,
     }
 
     if (found) {
-      val += item.at(keyname);
+      val += item.at(original_keyname);
     }
   }
 
@@ -359,11 +360,14 @@ Response ListResource::Completion(const std::string &cube_name, HelpType type,
   case HelpType::DEL:
     break;
   case HelpType::NONE:
-    if (configuration_) {
-      val += "add";
-      val += "del";
+    // suggest these commands only if we are not in the middle of a list
+    if (list_keys.size() == 0) {
+      if (configuration_) {
+        val += "add";
+        val += "del";
+      }
+      val += "show";
     }
-    val += "show";
     break;
   default:
     return {kBadRequest, nullptr};


### PR DESCRIPTION
List autocompletion was partially broken because a look up with the wrong key
name was done.

This commit also adds some logic to avoid suggesting the "add", "del", "show"
commands when in the middle of a list completion. ex:

polycubectl cube_name complex_list key1 <tab>:  suggest list of key2 for
elements that also matchs key1.
