### PR TITLE
libpolycube: fix cube get type

### DIFF
--- a/src/libs/polycube/include/polycube/services/base_cube.h
+++ b/src/libs/polycube/include/polycube/services/base_cube.h
@@ -97,7 +97,6 @@ class BaseCube {
 
   std::shared_ptr<BaseCubeIface> cube_;  // pointer to the cube in polycubed
   log_msg_cb handle_log_msg;
-  CubeType type_;
   std::shared_ptr<spdlog::logger> logger_;
   std::atomic<bool> dismounted_;
 

--- a/src/libs/polycube/src/base_cube.cpp
+++ b/src/libs/polycube/src/base_cube.cpp
@@ -116,7 +116,7 @@ const std::string BaseCube::getName() const {
 }
 
 CubeType BaseCube::get_type() const {
-  return type_;
+  return cube_->get_type();
 }
 
 std::shared_ptr<spdlog::logger> BaseCube::logger() {


### PR DESCRIPTION
get_type() was returning a local variable that was never set, so it always
returned CubeType::TC, this causes a performance degradation in pcn-iptables
because the fib_lookup kernel feature was never used.

