### PR TITLE
add service to base datamodel

### DIFF
--- a/src/polycubed/src/base_cube.cpp
+++ b/src/polycubed/src/base_cube.cpp
@@ -383,7 +383,7 @@ nlohmann::json BaseCube::to_json() const {
 
   j["name"] = name_;
   j["uuid"] = uuid_.str();
-  j["service"] = service_name_;
+  j["service-name"] = service_name_;
   j["type"] = cube_type_to_string(type_);
   j["loglevel"] = logLevelString(level_);
 

--- a/src/polycubed/src/base_model.cpp
+++ b/src/polycubed/src/base_model.cpp
@@ -89,6 +89,17 @@ Response BaseModel::get_parent(const std::string &cube_name) const {
   return Response{kOk, ::strdup(parent_name.data())};
 }
 
+Response BaseModel::get_service(const std::string &cube_name) const {
+  auto cube_ = ServiceController::get_cube(cube_name);
+  if (cube_ == nullptr) {
+    return Response{kNoContent, ::strdup("Cube does not exist")};
+  }
+
+  auto service_name = "\"" + cube_->get_service_name() + "\"";
+
+  return Response{kOk, ::strdup(service_name.data())};
+}
+
 Response BaseModel::get_port_uuid(const std::string &cube_name,
                                   const std::string &port_name) const {
   auto cube_ = ServiceController::get_cube(cube_name);

--- a/src/polycubed/src/base_model.h
+++ b/src/polycubed/src/base_model.h
@@ -34,6 +34,8 @@ class BaseModel {
 
   Response get_parent(const std::string &cube_name) const;
 
+  Response get_service(const std::string &cube_name) const;
+
   // polycube-standard-base module
   Response get_port_uuid(const std::string &cube_name,
                          const std::string &port_name) const;

--- a/src/polycubed/src/server/Resources/Data/BaseModel/ConcreteFactory.cpp
+++ b/src/polycubed/src/server/Resources/Data/BaseModel/ConcreteFactory.cpp
@@ -45,7 +45,7 @@ bool ConcreteFactory::IsBaseModel(
   if (tree_names_.size() == 1) {
     auto leaf = tree_names_.front();
     if (leaf == "type" || leaf == "uuid" || leaf == "loglevel" ||
-        leaf == "parent") {
+        leaf == "parent" || leaf == "service-name") {
       return true;
     }
   } else if (tree_names_.size() == 2) {
@@ -151,8 +151,13 @@ std::unique_ptr<Endpoint::LeafResource> ConcreteFactory::RestLeaf(
                                    const ListKeyValues &keys) -> Response {
         return local_core->base_model()->get_parent(cube_name);
       };
+    } else if (leaf == "service-name") {
+      read_handler_ = [local_core](const std::string &cube_name,
+                                   const ListKeyValues &keys) -> Response {
+        return local_core->base_model()->get_service(cube_name);
+      };
     } else {
-      throw std::runtime_error("unkown element found in base datamodel");
+      throw std::runtime_error("unkown element found in base datamodel:" + leaf);
     }
   } else if (tree_names_.size() == 2) {
     if (tree_names_.front() != "ports") {

--- a/src/polycubed/src/server/Resources/Endpoint/Service.h
+++ b/src/polycubed/src/server/Resources/Endpoint/Service.h
@@ -58,17 +58,13 @@ class Service : public ParentResource, public Body::Service {
 
  private:
   const std::string body_rest_endpoint_;
-  Validators::InSetValidator path_param_;
+  Validators::InSetValidator cube_names_;
 
   void CreateReplaceUpdate(const std::string &name, nlohmann::json &body,
                            ResponseWriter response, bool replace,
                            bool initialization);
 
   nlohmann::json getServiceKeys() const;
-
-  std::vector<Response> RequestValidate(
-      const Pistache::Rest::Request &request,
-      const std::string &caller_name) const final;
 
   void post(const Request &request, ResponseWriter response) final;
 

--- a/src/polycubed/src/server/Validators/InSetValidator.cpp
+++ b/src/polycubed/src/server/Validators/InSetValidator.cpp
@@ -20,7 +20,7 @@ namespace polycube::polycubed::Rest::Validators {
 InSetValidator::InSetValidator() : invalid_values_() {}
 
 bool InSetValidator::Validate(const std::string &value) const {
-  return invalid_values_.count(value) == 1;
+  return invalid_values_.count(value) == 0;
 }
 
 void InSetValidator::AddValue(const std::string &value) {

--- a/src/services/datamodel-common/polycube-base.yang
+++ b/src/services/datamodel-common/polycube-base.yang
@@ -72,6 +72,13 @@ module polycube-base {
       polycube-base:cli-example "TC";
     }
 
+    leaf service-name {
+      type string;
+      config true;
+      polycube-base:init-only-config;
+      polycube-base:cli-example "helloworld";
+    }
+
     leaf loglevel {
       type enumeration {
         enum TRACE;


### PR DESCRIPTION
There is an ongoing work to implement a /cubes/ api that will allow to create
a list of cubes with a single request.  In order to support that operation
there should be a service field that indicates the service type of the cube.

This commit adds the service to be base datamodel and updates polycubed to
support it.
