### PR TITLE
polycubed: fix segfault on init

### DIFF
--- a/src/polycubed/src/polycubed.cpp
+++ b/src/polycubed/src/polycubed.cpp
@@ -63,7 +63,7 @@ void shutdown() {
   if (core && restserver) {
     core->clear_servicectrl_list();
     restserver->shutdown();
-    logger->debug("rest was shutdown");
+    logger->debug("rest server shutdown");
     delete core;
     delete restserver;
   }

--- a/src/polycubed/src/polycubed.cpp
+++ b/src/polycubed/src/polycubed.cpp
@@ -60,10 +60,13 @@ void shutdown() {
     return;
   // Service controllers depend on Rest Server. It is required to remove them
   // before clearing the rest server in order to avoid segmentation faults.
-  core->clear_servicectrl_list();
-  restserver->shutdown();
-  logger->debug("rest was shutdown");
-  delete core;
+  if (core && restserver) {
+    core->clear_servicectrl_list();
+    restserver->shutdown();
+    logger->debug("rest was shutdown");
+    delete core;
+    delete restserver;
+  }
   logger->info("polycubed is shutting down. Bye!");
   done = true;
 }


### PR DESCRIPTION
When SIGINT was received at initialization time there was segfault because
the handler tried to delete the core and rest server that were not allocated
yet.  This commit adds a check to be sure that core and rest server are
allocated when the shutdown handler is invoked.

Solve: https://github.com/polycube-network/polycube/issues/49