### PR TITLE
polycubed: set missing default elements only at initialization time

### DIFF
--- a/src/polycubed/src/server/Resources/Body/ChoiceResource.cpp
+++ b/src/polycubed/src/server/Resources/Body/ChoiceResource.cpp
@@ -88,14 +88,13 @@ bool ChoiceResource::IsMandatory() const {
          dynamic_cast<const CaseResource *const>(parent_) != nullptr;
 }
 
-void ChoiceResource::SetDefaultIfMissing(nlohmann::json &body,
-                                         bool initialization) const {
+void ChoiceResource::SetDefaultIfMissing(nlohmann::json &body) const {
   if (default_case_ != nullptr) {
     auto def = std::find_if(
         std::begin(children_), std::end(children_),
         [this](const auto &child) { return child->Name() == *default_case_; });
     // no check if def is end because it ensured by YANG validation process
-    (*def)->SetDefaultIfMissing(body, initialization);
+    (*def)->SetDefaultIfMissing(body);
   }
 }
 }  // namespace polycube::polycubed::Rest::Resources::Body

--- a/src/polycubed/src/server/Resources/Body/ChoiceResource.h
+++ b/src/polycubed/src/server/Resources/Body/ChoiceResource.h
@@ -40,8 +40,7 @@ class ChoiceResource : public virtual ParentResource {
 
   bool IsMandatory() const final;
 
-  void SetDefaultIfMissing(nlohmann::json &body,
-                           bool initialization) const final;
+  void SetDefaultIfMissing(nlohmann::json &body) const final;
 
  private:
   const bool mandatory_;

--- a/src/polycubed/src/server/Resources/Body/LeafListResource.cpp
+++ b/src/polycubed/src/server/Resources/Body/LeafListResource.cpp
@@ -65,8 +65,7 @@ std::vector<Response> LeafListResource::BodyValidate(
   return errors;
 }
 
-void LeafListResource::SetDefaultIfMissing(nlohmann::json &body,
-                                           bool initialization) const {
+void LeafListResource::SetDefaultIfMissing(nlohmann::json &body) const {
   if (body.empty() && !default_.empty()) {
     for (const auto &element : default_) {
       body.push_back(element);

--- a/src/polycubed/src/server/Resources/Body/LeafListResource.h
+++ b/src/polycubed/src/server/Resources/Body/LeafListResource.h
@@ -40,8 +40,7 @@ class LeafListResource : public virtual LeafResource {
                                      nlohmann::json &body,
                                      bool initialization) const final;
 
-  void SetDefaultIfMissing(nlohmann::json &body,
-                           bool initialization) const final;
+  void SetDefaultIfMissing(nlohmann::json &body) const final;
 
  private:
   const std::vector<std::string> default_;

--- a/src/polycubed/src/server/Resources/Body/LeafResource.cpp
+++ b/src/polycubed/src/server/Resources/Body/LeafResource.cpp
@@ -61,8 +61,7 @@ std::vector<Response> LeafResource::BodyValidate(const std::string &cube_name,
   return errors;
 }
 
-void LeafResource::SetDefaultIfMissing(nlohmann::json &body,
-                                       bool initialization) const {
+void LeafResource::SetDefaultIfMissing(nlohmann::json &body) const {
   if (body.empty() && default_ != nullptr) {
     switch (type_) {
     case Types::Scalar::Integer:

--- a/src/polycubed/src/server/Resources/Body/LeafResource.h
+++ b/src/polycubed/src/server/Resources/Body/LeafResource.h
@@ -54,8 +54,7 @@ class LeafResource : public Resource {
     return configuration_;
   }
 
-  void SetDefaultIfMissing(nlohmann::json &body,
-                           bool initialization) const override;
+  void SetDefaultIfMissing(nlohmann::json &body) const override;
 
   nlohmann::json ToHelpJson() const override;
 

--- a/src/polycubed/src/server/Resources/Body/ListResource.cpp
+++ b/src/polycubed/src/server/Resources/Body/ListResource.cpp
@@ -85,8 +85,7 @@ const Response ListResource::ReadWhole(const std::string &cube_name,
   return ParentResource::ReadValue(cube_name, keys);
 }
 
-void ListResource::SetDefaultIfMissing(nlohmann::json &body,
-                                       bool initialization) const {
+void ListResource::SetDefaultIfMissing(nlohmann::json &body) const {
   // keys default values must be ignored (RFC7950#7.8.2)
   std::set<std::string> key_names;
   for (const auto &key : keys_) {
@@ -98,8 +97,8 @@ void ListResource::SetDefaultIfMissing(nlohmann::json &body,
     // all non-keys can be defaulted, otherwise only the ones that are not
     // marked as init-only-config.
     if (key_names.count(child->Name()) == 0 && child->IsConfiguration() &&
-        (initialization || !child->IsInitOnlyConfig())) {
-      child->SetDefaultIfMissing(body[child->Name()], initialization);
+        !child->IsInitOnlyConfig()) {
+      child->SetDefaultIfMissing(body[child->Name()]);
       if (body[child->Name()].empty()) {
         body.erase(child->Name());
       }
@@ -168,7 +167,9 @@ std::vector<Response> ListResource::BodyValidateMultiple(
   }
 
   for (auto &elem : jbody) {
-    SetDefaultIfMissing(elem, initialization);
+    if (initialization) {
+      SetDefaultIfMissing(elem);
+    }
     auto body = BodyValidate(cube_name, keys, elem, initialization);
     errors.reserve(errors.size() + body.size());
     std::copy(std::begin(body), std::end(body), std::back_inserter(errors));

--- a/src/polycubed/src/server/Resources/Body/ListResource.h
+++ b/src/polycubed/src/server/Resources/Body/ListResource.h
@@ -45,8 +45,7 @@ class ListResource : public virtual ParentResource {
 
   bool IsMandatory() const override;
 
-  void SetDefaultIfMissing(nlohmann::json &body,
-                           bool initialization) const final;
+  void SetDefaultIfMissing(nlohmann::json &body) const final;
 
   /*
    * This function takes the keys (parsed from the url in "keys") and save

--- a/src/polycubed/src/server/Resources/Body/ParentResource.cpp
+++ b/src/polycubed/src/server/Resources/Body/ParentResource.cpp
@@ -155,8 +155,7 @@ bool ParentResource::IsConfiguration() const {
                           });
 }
 
-void ParentResource::SetDefaultIfMissing(nlohmann::json &body,
-                                         bool initialization) const {
+void ParentResource::SetDefaultIfMissing(nlohmann::json &body) const {
   for (const auto &child : children_) {
     auto &child_body = body[child->Name()];
     // Lists can't be defaulted. The only possible this is if a list
@@ -165,16 +164,13 @@ void ParentResource::SetDefaultIfMissing(nlohmann::json &body,
     if (std::dynamic_pointer_cast<ListResource>(child) != nullptr) {
       if (!child_body.empty()) {
         for (auto &entry : child_body) {
-          child->SetDefaultIfMissing(entry, initialization);
+          child->SetDefaultIfMissing(entry);
         }
       }
     } else {
-      // Set default only for configuration nodes. During initialization
-      // all can be defaulted, otherwise only the ones that are not marked
-      // as init-only-config
-      if (child->IsConfiguration() &&
-          (initialization || !child->IsInitOnlyConfig())) {
-        child->SetDefaultIfMissing(child_body, initialization);
+      // Set default only for configuration nodes.
+      if (child->IsConfiguration()) {
+        child->SetDefaultIfMissing(child_body);
       }
     }
     if (child_body.empty()) {

--- a/src/polycubed/src/server/Resources/Body/ParentResource.h
+++ b/src/polycubed/src/server/Resources/Body/ParentResource.h
@@ -47,8 +47,7 @@ class ParentResource : public Resource {
 
   bool IsConfiguration() const final;
 
-  void SetDefaultIfMissing(nlohmann::json &body,
-                           bool initialization) const override;
+  void SetDefaultIfMissing(nlohmann::json &body) const override;
 
   std::shared_ptr<Resource> Child(const std::string &child_name) const;
 

--- a/src/polycubed/src/server/Resources/Body/Resource.h
+++ b/src/polycubed/src/server/Resources/Body/Resource.h
@@ -87,8 +87,7 @@ class Resource {
                                              nlohmann::json &body,
                                              bool initialization) const = 0;
 
-  virtual void SetDefaultIfMissing(nlohmann::json &body,
-                                   bool initialization) const = 0;
+  virtual void SetDefaultIfMissing(nlohmann::json &body) const = 0;
 
   inline const Body::ParentResource *const Parent() const {
     return parent_;

--- a/src/polycubed/src/server/Resources/Endpoint/LeafResource.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/LeafResource.cpp
@@ -98,7 +98,7 @@ void LeafResource::CreateReplaceUpdate(const Pistache::Rest::Request &request,
   // This method can be reached only as direct call on the update method
   // of this LeafResource. It is possible only for configuration
   // nodes not marked as init-only-config.
-  SetDefaultIfMissing(jbody, false);
+  SetDefaultIfMissing(jbody);
 
   const auto cube_name = Service::Cube(request);
   ListKeyValues keys{};

--- a/src/polycubed/src/server/Resources/Endpoint/ListResource.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/ListResource.cpp
@@ -160,7 +160,9 @@ void ListResource::CreateReplaceUpdateWhole(
   ListKeyValues keys{};
   dynamic_cast<const ParentResource *const>(parent_)->Keys(request, keys);
   for (auto &elem : jbody) {
-    SetDefaultIfMissing(elem, initialization);
+    if (initialization) {
+      SetDefaultIfMissing(elem);
+    }
     auto body = BodyValidate(cube_name, keys, elem, initialization);
     errors.reserve(errors.size() + body.size());
     std::copy(std::begin(body), std::end(body), std::back_inserter(errors));

--- a/src/polycubed/src/server/Resources/Endpoint/ParentResource.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/ParentResource.cpp
@@ -100,7 +100,9 @@ void ParentResource::CreateReplaceUpdate(
 
   // Mandatory value is checked only during POST and PUT, both
   // considered as initialization operations.
-  SetDefaultIfMissing(jbody, initialization);
+  if (initialization) {
+    SetDefaultIfMissing(jbody);
+  }
 
   const auto &cube_name = Service::Cube(request);
   ListKeyValues keys{};

--- a/src/polycubed/src/server/Resources/Endpoint/Service.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/Service.cpp
@@ -73,7 +73,9 @@ void Service::CreateReplaceUpdate(const std::string &name, nlohmann::json &body,
   if (update || !ServiceController::exists_cube(name)) {
     auto op = OperationType(update, initialization);
     auto k = ListKeyValues{};
-    SetDefaultIfMissing(body, initialization);
+    if (initialization) {
+      SetDefaultIfMissing(body);
+    }
 
     auto jbody = body;
     jbody.erase("name");


### PR DESCRIPTION
polycubed fills the default elements on a request if they are missing, this
guarantees that the default elements are always set when the request arrives to
the service implementation, hence the developer has not to take care of it.

When an update (PATCH) request is done those fields should not be set, because
their value will be modified even if the client wanted to update other elements.
