### PR TITLE
polycubed: fix issue with lists and default elements

### DIFF
--- a/src/polycubed/src/server/Resources/Body/ListResource.h
+++ b/src/polycubed/src/server/Resources/Body/ListResource.h
@@ -45,8 +45,6 @@ class ListResource : public virtual ParentResource {
 
   bool IsMandatory() const override;
 
-  void SetDefaultIfMissing(nlohmann::json &body) const final;
-
   /*
    * This function takes the keys (parsed from the url in "keys") and save
    * them in the body of the request


### PR DESCRIPTION
The logic to set default elements in a list was broken as it was trying
to fill the elements as if the list were a container.

This commit reworks the logic to fill default elements, in a list they
are filled only if there are children in the request.
