### PR TITLE
Netlink change: Namespace support and event extension

### DIFF
--- a/src/polycubed/src/netlink.h
+++ b/src/polycubed/src/netlink.h
@@ -48,11 +48,10 @@ class Observer;  // a passible subscriber callback class
 
 class Netlink {
  public:
-  Netlink();
   ~Netlink();
 
   // TODO: Add here new events needed for the future
-  enum Event { LINK_DELETED, ALL };
+  enum Event { LINK_ADDED, LINK_DELETED, ROUTE_ADDED, ROUTE_DELETED, NEW_ADDRESS, ALL };
   // enum Event { LINK_DELETED };
   static Netlink &getInstance() {
     static Netlink instance;
@@ -103,7 +102,12 @@ class Netlink {
   }
 
  private:
+  Netlink();
   void notify_link_deleted(int ifindex, const std::string &iface);
+  void notify_link_added(int ifindex, const std::string &iface);
+  void notify_route_added(int ifindex, const std::string &info_route);
+  void notify_route_deleted(int ifindex, const std::string &info_route);
+  void notify_new_address(int ifindex, const std::string &info_address);
   void notify_all(int ifindex, const std::string &iface);
 
   std::shared_ptr<spdlog::logger> logger;

--- a/src/services/pcn-iptables/src/Iptables.cpp
+++ b/src/services/pcn-iptables/src/Iptables.cpp
@@ -20,7 +20,8 @@
 #include "Iptables_dp.h"
 
 Iptables::Iptables(const std::string name, const IptablesJsonObject &conf)
-    : Cube(conf.getBase(), {iptables_code_ingress}, {iptables_code_egress}) {
+    : Cube(conf.getBase(), {iptables_code_ingress}, {iptables_code_egress}),
+    netlink_instance_iptables_(polycube::polycubed::Netlink::getInstance()) {
   logger()->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [Iptables] [%n] [%l] %v");
   logger()->info("Creating Iptables instance");
 

--- a/src/services/pcn-iptables/src/Iptables.h
+++ b/src/services/pcn-iptables/src/Iptables.h
@@ -175,7 +175,7 @@ class Iptables : public polycube::service::Cube<Ports>,
   std::mutex mutex_iptables_;
 
   int netlink_notification_index_;
-  polycube::polycubed::Netlink netlink_instance_iptables_;
+  polycube::polycubed::Netlink &netlink_instance_iptables_;
 
   // interactive mode
   bool interactive_ = true;
@@ -319,7 +319,7 @@ class Iptables : public polycube::service::Cube<Ports>,
 
     // use a new instance of netlink for each chainselector
     // prevent deadlocks with main instance present in polycubed
-    polycube::polycubed::Netlink netlink_instance_chainselector_;
+    polycube::polycubed::Netlink &netlink_instance_chainselector_;
     int netlink_notification_index_chainselector_;
   };
 

--- a/src/services/pcn-iptables/src/modules/ChainSelector.cpp
+++ b/src/services/pcn-iptables/src/modules/ChainSelector.cpp
@@ -24,7 +24,9 @@ Iptables::ChainSelector::ChainSelector(const int &index, Iptables &outer,
                         (t == ProgramType::INGRESS)
                             ? ChainNameEnum::INVALID_INGRESS
                             : ChainNameEnum::INVALID_EGRESS,
-                        outer, t) {
+                        outer, t) ,
+    netlink_instance_chainselector_(
+        polycube::polycubed::Netlink::getInstance()) {
   load();
 
   updateLocalIps();


### PR DESCRIPTION
Socket replacement:
Replacement of the libnl library socket with a raw socket; because in this way it is possible to receive netlink notifications even from the network namespaces.

Added new netlink events:
LINK_ADDED, ROUTE_ADDED, ROUTE_DELETED, NEW_ADDRESS

Removed netlink event ALL (notify_all):
Having a notification without a type is considered not very useful