### PR TITLE
polycubed: show parent when attached to a netdev

### DIFF
--- a/src/polycubed/src/extiface.cpp
+++ b/src/polycubed/src/extiface.cpp
@@ -251,5 +251,9 @@ bool ExtIface::is_used() const {
   return cubes_.size() > 0 || peer_ != nullptr;
 }
 
+std::string ExtIface::get_iface_name() const {
+  return iface_;
+}
+
 }  // namespace polycubed
 }  // namespace polycube

--- a/src/polycubed/src/extiface.h
+++ b/src/polycubed/src/extiface.h
@@ -48,6 +48,8 @@ class ExtIface : public PeerIface {
   void set_next_index(uint16_t index);
   bool is_used() const;
 
+  std::string get_iface_name() const;
+
  protected:
   static std::set<std::string> used_ifaces;
   int load_ingress();

--- a/src/polycubed/src/transparent_cube.cpp
+++ b/src/polycubed/src/transparent_cube.cpp
@@ -151,8 +151,11 @@ nlohmann::json TransparentCube::to_json() const {
 
   std::string parent;
   if (parent_) {
-    auto port_parent = dynamic_cast<Port *>(parent_);
-    parent = port_parent->get_path();
+    if (auto port_parent = dynamic_cast<Port *>(parent_)) {
+      parent = port_parent->get_path();
+    } else if (auto iface_parent = dynamic_cast<ExtIface *>(parent_)) {
+      parent = iface_parent->get_iface_name();
+    }
   }
 
   j["parent"] = parent;


### PR DESCRIPTION
A transparent cube can be attached to a standard cube's port or to a netdev,
the conversion to json was failing to show it when the cube was attached to a
netdev.

