### PR TITLE
Add feature loadtopology

### DIFF
--- a/Documentation/polycubectl/polycubectl.rst
+++ b/Documentation/polycubectl/polycubectl.rst
@@ -15,7 +15,8 @@ How to use
 ----------
 
 **NOTE**: ``polycubed`` must be running, in order to use ``polycubectl``.
-You can start the daemon typing ``sudo polycubed`` in another terminal. Refer to :doc:`Quick Start <../quickstart>`.
+You can start the daemon typing ``sudo polycubed`` in another terminal.
+Refer to :doc:`Quick Start <../quickstart>`.
 
 ``polycubectl`` is a generic CLI, that enables the user to interact with ``Cubes`` (``bridge``, ``router``, ...) and with some framework primitives to ``connect``, ``show`` and build complex ``topologies``.
 
@@ -23,9 +24,6 @@ You can start the daemon typing ``sudo polycubed`` in another terminal. Refer to
 
         # Show help
         polycubectl --help
-
-::
-
         Keyword           Type      Description
         simpleforwarder   service   Simple Forwarder Base Service
         simplebridge      service   Simple L2 Bridge Service
@@ -45,14 +43,71 @@ You can start the daemon typing ``sudo polycubed`` in another terminal. Refer to
         connect           command   Connect ports
         disconnect        command   Disconnect ports
 
-        attach                  command   Attach transparent cubes
-        detach                  command   Detach transparent cubes
+        attach            command   Attach transparent cubes
+        detach            command   Detach transparent cubes
 
         services          command   Show/Add/Del services (e.g. Bridge, Router, ..)
         cubes             command   Show running service instances (e.g. br1, nat2, ..)
         topology          command   Show topology of service instances
         netdevs           command   Show net devices available
 
+``polycubectl`` is service agnostic, hence the syntax is service dependent.
+However we can generalize the syntax as:
+
+::
+
+        polycubectl [parent] [command] [child] [argument0=value0] [argument1=value1]
+
+
+- ``parent``: path of the parent resource where the command has to be applied.
+- ``command``: ``add``, ``del``, ``show``, ``set`` or a yang action.
+- ``child``: specific resource where the command is applied.
+- ``argument``: some commands accept additional commands that are sent in the body request.
+
+Some examples:
+
+::
+
+        polycubectl router r0 add loglevel=debug
+        polycubectl r0 ports add port1 ip=10.1.0.1 netmask=255.255.0.0
+        polycubectl r0 show routing table
+        polycubectl r0 ports port1 set peer=veth1
+        polycubectl r0 ports del port1
+
+        # yang action
+        polycubectl firewall1 chain ingress append src=10.0.0.1 action=DROP
+
+
+The best way to know what is the syntax for each service is to use the `Help`_ or the bash completion by pressing ``<TAB>`` at any point.
+
+
+``polycubectl`` is also able to read the contents of the request from the standard input, it can be used in two ways:
+
+Passing complex configuration from the command line
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+        # create a helloworld instance with loglevel debug and action forward
+        polycubectl helloworld add hw0 << EOF
+        {
+        "loglevel": "debug",
+        "action": "forward"
+        }
+        EOF
+
+
+Reading configuration from a file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+        # create helloworld from a yaml file
+        polycubectl helloworld add hw0 < hw0.yaml
+
+        # create a router from a json file
+        polycubectl router add r0 < r0.json
+
+        # add a list of cubes
+        polycubectl cubes add < mycubes.yaml
 
 Help
 ^^^^
@@ -124,7 +179,8 @@ More complete examples are available in :doc:`tutorials <../tutorials/index>`.
 Configuration
 -------------
 
-By default, the CLI contacts ``polycubed`` daemon at ``http://localhost:9000/polycube/v1/``. The user can override this configuration with following instructions.
+By default, ``polycubectl`` contacts ``polycubed`` at ``http://localhost:9000/polycube/v1/``.
+The user can override this configuration with following instructions.
 
 Parameters
 ^^^^^^^^^^

--- a/src/polycubectl/aliases.go
+++ b/src/polycubectl/aliases.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	//"reflect"
 	"github.com/polycube-network/polycube/src/polycubectl/cliargs"
 )
 

--- a/src/polycubectl/cliargs/cliargs.go
+++ b/src/polycubectl/cliargs/cliargs.go
@@ -21,6 +21,11 @@ import (
 	"strconv"
 	"strings"
 
+	"os"
+	"bufio"
+	"bytes"
+	"github.com/ghodss/yaml"
+
 	"github.com/polycube-network/polycube/src/polycubectl/config"
 	"github.com/polycube-network/polycube/src/polycubectl/httprequest"
 
@@ -441,7 +446,25 @@ func (cli *CLIArgs) GetHTTPRequest() (*httprequest.HTTPRequest, error) {
 			url += url0
 			body = body0
 		} else {
-			body = cli.buildBody()
+			// if there is text on the standard input that'll used as the body
+			var buffer bytes.Buffer
+			reader := bufio.NewReader(os.Stdin)
+			text, _ := reader.ReadString('\n')
+			for text != "" {
+				buffer.WriteString(text)
+				text, _ = reader.ReadString('\n')
+			}
+
+			if buffer.Len() > 0 {
+				jsonBuff, err := yaml.YAMLToJSON(buffer.Bytes())
+				if err != nil {
+					return nil, err
+				} else {
+					body = jsonBuff
+				}
+			} else {
+				body = cli.buildBody()
+			}
 		}
 	}
 

--- a/src/polycubed/src/rest_server.cpp
+++ b/src/polycubed/src/rest_server.cpp
@@ -171,6 +171,9 @@ void RestServer::setup_routes() {
   router_->get(base + std::string("/cubes/:cubeName"),
                bind(&RestServer::get_cube, this));
 
+  router_->post(base + std::string("/cubes"),
+                bind(&RestServer::post_cubes, this));
+
   router_->options(base + std::string("/cubes"),
                    bind(&RestServer::cubes_help, this));
 
@@ -422,6 +425,31 @@ void RestServer::get_cube(const Pistache::Rest::Request &request,
     auto name = request.param(":cubeName").as<std::string>();
     std::string retJsonStr = core.get_cube(name);
     response.send(Pistache::Http::Code::Ok, retJsonStr);
+  } catch (const std::runtime_error &e) {
+    logger->error("{0}", e.what());
+    response.send(Pistache::Http::Code::Bad_Request, e.what());
+  }
+}
+
+void RestServer::post_cubes(const Pistache::Rest::Request &request,
+                               Pistache::Http::ResponseWriter response) {
+  logRequest(request);
+  try {
+    json j = json::parse(request.body());
+    logJson(j);
+    std::vector<Response> resp = {{ErrorTag::kNoContent, nullptr}};
+    bool error = false;
+    for (auto &it : j) {
+      resp = core.get_service_controller(it["service-name"]).get_management_interface()->get_service()
+              ->CreateReplaceUpdate(it["name"], it, false, true);
+      if (!error && resp[0].error_tag != kCreated) {
+        Rest::Server::ResponseGenerator::Generate(std::move(resp), std::move(response));
+        error = true;
+      }
+    }
+    if (!error) {
+      Rest::Server::ResponseGenerator::Generate(std::move(resp), std::move(response));
+    }
   } catch (const std::runtime_error &e) {
     logger->error("{0}", e.what());
     response.send(Pistache::Http::Code::Bad_Request, e.what());

--- a/src/polycubed/src/rest_server.h
+++ b/src/polycubed/src/rest_server.h
@@ -85,6 +85,9 @@ class RestServer {
   void get_cube(const Pistache::Rest::Request &request,
                 Pistache::Http::ResponseWriter response);
 
+    void post_cubes(const Pistache::Rest::Request &request,
+                       Pistache::Http::ResponseWriter response);
+
   void cubes_help(const Pistache::Rest::Request &request,
                   Pistache::Http::ResponseWriter response);
 

--- a/src/polycubed/src/server/Resources/Endpoint/Service.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/Service.cpp
@@ -67,9 +67,8 @@ void Service::ClearCubes() {
   }
 }
 
-void Service::CreateReplaceUpdate(const std::string &name, nlohmann::json &body,
-                                  ResponseWriter response, bool update,
-                                  bool initialization) {
+std::vector<Response>
+Service::CreateReplaceUpdate(const std::string &name, nlohmann::json &body, bool update, bool initialization) {
   if (update || !ServiceController::exists_cube(name)) {
     auto op = OperationType(update, initialization);
     auto k = ListKeyValues{};
@@ -80,9 +79,7 @@ void Service::CreateReplaceUpdate(const std::string &name, nlohmann::json &body,
 
     auto body_errors = BodyValidate(name, k, jbody, initialization);
     if (!body_errors.empty()) {
-      Server::ResponseGenerator::Generate(std::move(body_errors),
-                                          std::move(response));
-      return;
+      return std::move(body_errors);
     }
 
     auto resp = WriteValue(name, body, k, op);
@@ -91,12 +88,9 @@ void Service::CreateReplaceUpdate(const std::string &name, nlohmann::json &body,
                     resp.error_tag == ErrorTag::kNoContent)) {
       cube_names_.AddValue(name);
     }
-    Server::ResponseGenerator::Generate(std::vector<Response>{resp},
-                                        std::move(response));
+    return std::vector<Response>{resp};
   } else {
-    Server::ResponseGenerator::Generate(
-        std::vector<Response>{{ErrorTag::kDataExists, nullptr}},
-        std::move(response));
+    return std::vector<Response>{{ErrorTag::kDataExists, nullptr}};
   }
 }
 
@@ -127,8 +121,8 @@ void Service::post_body(const Request &request, ResponseWriter response) {
     return;
   }
 
-  CreateReplaceUpdate(body["name"].get<std::string>(), body,
-                      std::move(response), false, true);
+  auto resp = CreateReplaceUpdate(body["name"].get<std::string>(), body, false, true);
+  Server:: ResponseGenerator::Generate(std::move(resp), std::move(response));
 }
 
 void Service::post(const Request &request, ResponseWriter response) {
@@ -149,7 +143,8 @@ void Service::post(const Request &request, ResponseWriter response) {
     }
   }
 
-  CreateReplaceUpdate(name, body, std::move(response), false, true);
+  auto resp = CreateReplaceUpdate(name, body, false, true);
+  Server:: ResponseGenerator::Generate(std::move(resp), std::move(response));
 }
 
 void Service::put(const Request &request, ResponseWriter response) {
@@ -161,7 +156,8 @@ void Service::put(const Request &request, ResponseWriter response) {
     body = nlohmann::json::parse(request.body());
   }
   body["name"] = name;
-  CreateReplaceUpdate(name, body, std::move(response), false, true);
+  auto resp = CreateReplaceUpdate(name, body, false, true);
+  Server:: ResponseGenerator::Generate(std::move(resp), std::move(response));
 }
 
 void Service::patch(const Request &request, ResponseWriter response) {
@@ -173,7 +169,8 @@ void Service::patch(const Request &request, ResponseWriter response) {
     body = nlohmann::json::parse(request.body());
   }
   body["name"] = name;
-  CreateReplaceUpdate(name, body, std::move(response), true, false);
+  auto resp = CreateReplaceUpdate(name, body, true, false);
+  Server:: ResponseGenerator::Generate(std::move(resp), std::move(response));
 }
 
 void Service::del(const Pistache::Rest::Request &request,
@@ -201,8 +198,8 @@ void Service::patch_body(const Request &request, ResponseWriter response) {
         std::move(response));
     return;
   }
-  CreateReplaceUpdate(body["name"].get<std::string>(), body,
-                      std::move(response), true, false);
+  auto resp = CreateReplaceUpdate(body["name"].get<std::string>(), body, true, false);
+  Server:: ResponseGenerator::Generate(std::move(resp), std::move(response));
 }
 
 void Service::options_body(const Request &request, ResponseWriter response) {

--- a/src/polycubed/src/server/Resources/Endpoint/Service.h
+++ b/src/polycubed/src/server/Resources/Endpoint/Service.h
@@ -56,13 +56,12 @@ class Service : public ParentResource, public Body::Service {
 
   virtual Response ReadHelp() = 0;
 
+  std::vector<Response> CreateReplaceUpdate(const std::string &name, nlohmann::json &body,
+                                            bool update, bool initialization);
+
  private:
   const std::string body_rest_endpoint_;
   Validators::InSetValidator cube_names_;
-
-  void CreateReplaceUpdate(const std::string &name, nlohmann::json &body,
-                           ResponseWriter response, bool replace,
-                           bool initialization);
 
   nlohmann::json getServiceKeys() const;
 


### PR DESCRIPTION
This PR adds two features to make the configuration of polycube more user friendly.

- a new /cupes/ api is created in polycubed, this allows to create multiple cubes at the time with a single request. This can be used to load the full configuration of a network topology.
- the CLI has been extended to support reading complex configurations from the command line and from files. For instance a full topology can be deployed by `polycubectl  cubes add < my_network.yaml`. This feature is available to all commands.

