### PR TITLE
tests: check for services to be loaded before starting test

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -2,3 +2,4 @@ test_log*
 test_results*
 tmp
 result.json
+load_services

--- a/tests/helpers_tests.bash
+++ b/tests/helpers_tests.bash
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+
+# cleanup environment before exit
+function cleanup {
+  set +e
+  echo "killing polycubed ..."
+  sudo pkill polycubed >> $test_tmp
+  echo "{ \"passed\":\"$test_passed\", \"total\":\"$test_total\", \"test_log\":\"$test_log\" }" > $RESULT_JSON
+
+  cat $test_results
+
+  echo ""
+  echo "FAILED TESTS:"
+  echo ""
+  cat $test_results | grep FAILED -A 1
+
+  if $failed ; then
+    exit 1
+  fi
+}
+
+# execute and log test ($1:path)
+function log_test {
+  "$@" >> $test_tmp 2>&1
+  local status=$?
+  last_test_result=$status
+
+  # check if polycubed is still alive (no crash in the meanwhile)
+  polycubed_alive=$(ps -el | grep polycubed)
+  if [ -z "$polycubed_alive" ]; then
+    echo "polycubed not running ..."
+    polycubed_crash=true
+    status=1
+  fi
+  test_total=$(($test_total+1))
+  if [ $status -ne 0 ]; then
+    echo "++++TEST $1 FAILED++++"
+    echo "++++TEST $1 FAILED++++" >> $test_results
+    echo "++++TEST $1 FAILED++++" >> $test_tmp
+    failed=true
+    cat $test_tmp >> $test_log
+  else
+    test_passed=$(($test_passed+1))
+    echo "++++TEST $1 PASSED++++"
+    echo "++++TEST $1 PASSED++++" >> $test_results
+    echo "++++TEST $1 PASSED++++" >> $test_tmp
+  fi
+  return $status
+}
+
+# Check if services are loaded
+function services_are_loaded {
+  echo "load_services:" > load_services
+  count=0
+  services_show=$(polycubectl services show)
+  for i in "${!services[@]}"
+  do
+    lines=$(echo $services_show | grep $i | wc -l)
+    if [ $lines -ne 0 ]
+    then
+      echo "$i YES" >> load_services
+    else
+      count=$((count + 1))
+      echo "$i NO" >> load_services
+    fi
+  done
+  echo $count
+}
+
+# Check if polycubed rest server is responding
+function polycubed_is_responding {
+  ret=$(polycubectl ? > /dev/null)
+  ret=$(echo $?)
+  echo $ret
+}
+
+# Kill polycubed, and wait all services to be unloaded and process to be completely killed
+function polycubed_kill_and_wait {
+  echo "killing polycubed ..."
+  sudo pkill polycubed >> $test_tmp
+
+  done=0
+  i=0
+  while : ; do
+    sleep 1
+    alive=$(ps -el | grep polycubed)
+    if [ -z "$alive" ]; then
+      done=1
+    fi
+
+    i=$((i+1))
+
+    if [ "$done" -ne 0 ]; then
+        echo "killing polycubed in $i seconds"
+        break
+    fi
+  done
+}
+
+# Relaunch polycubed, if deamon is not running
+function polycubed_relaunch_if_not_running {
+  alive=$(ps -el | grep polycubed)
+  if [ -z "$alive" ]; then
+    echo "polycubed not running ..."
+    echo "relaunching polycubed ..."
+    $polycubed >> $test_tmp 2>&1 &
+  fi
+}
+
+# Launch polycubed, and wait until it becomes responsive
+function launch_and_wait_polycubed_is_responding {
+  if $RELAUNCH_POLYCUBED; then
+    echo "starting polycubed ..."
+    $polycubed >> $test_tmp 2>&1 &
+  else
+    polycubed_alive=$(ps -el | grep polycubed)
+    if [ -z "$polycubed_alive" ]; then
+      echo "polycubed not running ..."
+      echo "relaunching polycubed ..."
+      $polycubed >> $test_tmp 2>&1 &
+    fi
+  fi
+
+  done=0
+  i=0
+  while : ; do
+    sleep 1
+    responding=$(polycubed_is_responding)
+    if [[ $responding -eq 0 ]]; then
+      done=1
+    else
+      polycubed_relaunch_if_not_running
+    fi
+    i=$((i+1))
+    if [ "$done" -ne 0 ]; then
+      if $RELAUNCH_POLYCUBED; then
+        echo "starting polycubed in $i seconds"
+      else
+        if [ -z "$polycubed_alive" ]; then
+          echo "relaunching polycubed in $i seconds"
+        fi
+      fi
+        break
+    fi
+  done
+
+  done=0
+  i=0
+  while : ; do
+    sleep 1
+    loaded=$(services_are_loaded)
+    if [[ $loaded -eq 0 ]]; then
+      done=1
+    fi
+
+    i=$((i+1))
+    if [ "$i" -eq $SERVICES_LOAD_TIMEOUT ]
+    then
+        echo "+ERROR+ timeout in checking services loaded $i seconds. try to run test anyway"
+        cat load_services | grep NO
+        break
+    fi
+    if [ "$done" -ne 0 ]; then
+        echo "checking services loaded in $i seconds"
+        break
+    fi
+  done
+}
+
+# run test ($1:path)
+function run_test {
+  polycubed_crash=false
+  STARTTIME=$(date +%s)
+  echo
+  echo "Starting test $1 ..."
+  echo "++++Starting test $1++++" > $test_tmp
+  launch_and_wait_polycubed_is_responding
+  echo "executing test ..."
+  log_test $1
+  if $RELAUNCH_POLYCUBED; then
+   polycubed_kill_and_wait
+  fi
+  echo "Finished test $1"
+  ENDTIME=$(date +%s)
+  echo "Time elapsed: $(($ENDTIME - $STARTTIME))s"
+  echo "Time elapsed: $(($ENDTIME - $STARTTIME))s" >> $test_results
+  echo "Time elapsed: $(($ENDTIME - $STARTTIME))s" >> $test_tmp
+  echo "++++Finished test $1++++" >> $test_tmp
+}
+

--- a/tests/run-tests-iptables.sh
+++ b/tests/run-tests-iptables.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source "${BASH_SOURCE%/*}/helpers_tests.bash"
+
 # use a clean instance of polycubed to run each test
 RELAUNCH_POLYCUBED=true
 
@@ -14,24 +16,6 @@ RESULT_JSON="result.json"
 declare -A services
 services[iptables]=pcn-iptables
 
-# cleanup environment before exit
-function cleanup {
-  set +e
-  echo "killing polycubed ..."
-  sudo pkill polycubed >> $test_tmp
-  echo "{ \"passed\":\"$test_passed\", \"total\":\"$test_total\", \"test_log\":\"$test_log\" }" > $RESULT_JSON
-
-  cat $test_results
-
-  echo ""
-  echo "FAILED TESTS:"
-  echo ""
-  cat $test_results | grep FAILED -A 1
-
-  if $failed ; then
-    exit 1
-  fi
-}
 trap cleanup EXIT
 
 # $1 setup RELAUNCH_POLYCUBED
@@ -68,175 +52,6 @@ echo >> $test_results
 echo "Tests Scripts - LOG FILE" > $test_log
 date >> $test_log
 echo >> $test_log
-
-# execute and log test ($1:path)
-function log_test {
-  "$@" >> $test_tmp 2>&1
-  local status=$?
-  last_test_result=$status
-
-  # check if polycubed is still alive (no crash in the meanwhile)
-  polycubed_alive=$(ps -el | grep polycubed)
-  if [ -z "$polycubed_alive" ]; then
-    echo "polycubed not running ..."
-    polycubed_crash=true
-    status=1
-  fi
-  test_total=$(($test_total+1))
-  if [ $status -ne 0 ]; then
-    echo "++++TEST $1 FAILED++++"
-    echo "++++TEST $1 FAILED++++" >> $test_results
-    echo "++++TEST $1 FAILED++++" >> $test_tmp
-    failed=true
-    cat $test_tmp >> $test_log
-  else
-    test_passed=$(($test_passed+1))
-    echo "++++TEST $1 PASSED++++"
-    echo "++++TEST $1 PASSED++++" >> $test_results
-    echo "++++TEST $1 PASSED++++" >> $test_tmp
-  fi
-  return $status
-}
-
-# Check if services are loaded
-function services_are_loaded {
-  echo "load_services:" > load_services
-  count=0
-  services_show=$(polycubectl services show)
-  for i in "${!services[@]}"
-  do
-    lines=$(echo $services_show | grep $i | wc -l)
-    if [ $lines -ne 0 ]
-    then
-      echo "$i YES" >> load_services
-    else
-      count=$((count + 1))
-      echo "$i NO" >> load_services
-    fi
-  done
-  echo $count
-}
-
-# Check if polycubed rest server is responding
-function polycubed_is_responding {
-  ret=$(polycubectl ? > /dev/null)
-  ret=$(echo $?)
-  echo $ret
-}
-
-# Kill polycubed, and wait all services to be unloaded and process to be completely killed
-function polycubed_kill_and_wait {
-  echo "killing polycubed ..."
-  sudo pkill polycubed >> $test_tmp
-
-  done=0
-  i=0
-  while : ; do
-    sleep 1
-    alive=$(ps -el | grep polycubed)
-    if [ -z "$alive" ]; then
-      done=1
-    fi
-
-    i=$((i+1))
-
-    if [ "$done" -ne 0 ]; then
-        echo "killing polycubed in $i seconds"
-        break
-    fi
-  done
-}
-
-# Relaunch polycubed, if deamon is not running
-function polycubed_relaunch_if_not_running {
-  alive=$(ps -el | grep polycubed)
-  if [ -z "$alive" ]; then
-    echo "polycubed not running ..."
-    echo "relaunching polycubed ..."
-    $polycubed >> $test_tmp 2>&1 &
-  fi
-}
-
-# Launch polycubed, and wait until it becomes responsive
-function launch_and_wait_polycubed_is_responding {
-  if $RELAUNCH_POLYCUBED; then
-    echo "starting polycubed ..."
-    $polycubed >> $test_tmp 2>&1 &
-  else
-    polycubed_alive=$(ps -el | grep polycubed)
-    if [ -z "$polycubed_alive" ]; then
-      echo "polycubed not running ..."
-      echo "relaunching polycubed ..."
-      $polycubed >> $test_tmp 2>&1 &
-    fi
-  fi
-
-  done=0
-  i=0
-  while : ; do
-    sleep 1
-    responding=$(polycubed_is_responding)
-    if [[ $responding -eq 0 ]]; then
-      done=1
-    else
-      polycubed_relaunch_if_not_running
-    fi
-    i=$((i+1))
-    if [ "$done" -ne 0 ]; then
-      if $RELAUNCH_POLYCUBED; then
-        echo "starting polycubed in $i seconds"
-      else
-        if [ -z "$polycubed_alive" ]; then
-          echo "relaunching polycubed in $i seconds"
-        fi
-      fi
-        break
-    fi
-  done
-
-  done=0
-  i=0
-  while : ; do
-    sleep 1
-    loaded=$(services_are_loaded)
-    if [[ $loaded -eq 0 ]]; then
-      done=1
-    fi
-
-    i=$((i+1))
-    if [ "$i" -eq $SERVICES_LOAD_TIMEOUT ]
-    then
-        echo "+ERROR+ timeout in checking services loaded $i seconds. try to run test anyway"
-        cat load_services | grep NO
-        break
-    fi
-    if [ "$done" -ne 0 ]; then
-        echo "checking services loaded in $i seconds"
-        break
-    fi
-  done
-}
-
-# run test ($1:path)
-function run_test {
-  polycubed_crash=false
-  STARTTIME=$(date +%s)
-  echo
-  echo "Starting test $1 ..."
-  echo "++++Starting test $1++++" > $test_tmp
-  launch_and_wait_polycubed_is_responding
-  echo "executing test ..."
-  log_test $1
-  if $RELAUNCH_POLYCUBED; then
-   polycubed_kill_and_wait
-  fi
-  echo "Finished test $1"
-  ENDTIME=$(date +%s)
-  echo "Time elapsed: $(($ENDTIME - $STARTTIME))s"
-  echo "Time elapsed: $(($ENDTIME - $STARTTIME))s" >> $test_results
-  echo "Time elapsed: $(($ENDTIME - $STARTTIME))s" >> $test_tmp
-  echo "++++Finished test $1++++" >> $test_tmp
-}
 
 function run_tests_from_dir {
   for test in $1local_test*.sh; do

--- a/tests/run-tests-iptables.sh
+++ b/tests/run-tests-iptables.sh
@@ -3,11 +3,16 @@
 # use a clean instance of polycubed to run each test
 RELAUNCH_POLYCUBED=true
 
+SERVICES_LOAD_TIMEOUT=10
+
 # launch polycubed in DEBUG mode
 DEBUG=false
 
 # result.json path
 RESULT_JSON="result.json"
+
+declare -A services
+services[iptables]=pcn-iptables
 
 # cleanup environment before exit
 function cleanup {
@@ -93,6 +98,25 @@ function log_test {
   return $status
 }
 
+# Check if services are loaded
+function services_are_loaded {
+  echo "load_services:" > load_services
+  count=0
+  services_show=$(polycubectl services show)
+  for i in "${!services[@]}"
+  do
+    lines=$(echo $services_show | grep $i | wc -l)
+    if [ $lines -ne 0 ]
+    then
+      echo "$i YES" >> load_services
+    else
+      count=$((count + 1))
+      echo "$i NO" >> load_services
+    fi
+  done
+  echo $count
+}
+
 # Check if polycubed rest server is responding
 function polycubed_is_responding {
   ret=$(polycubectl ? > /dev/null)
@@ -166,6 +190,28 @@ function launch_and_wait_polycubed_is_responding {
           echo "relaunching polycubed in $i seconds"
         fi
       fi
+        break
+    fi
+  done
+
+  done=0
+  i=0
+  while : ; do
+    sleep 1
+    loaded=$(services_are_loaded)
+    if [[ $loaded -eq 0 ]]; then
+      done=1
+    fi
+
+    i=$((i+1))
+    if [ "$i" -eq $SERVICES_LOAD_TIMEOUT ]
+    then
+        echo "+ERROR+ timeout in checking services loaded $i seconds. try to run test anyway"
+        cat load_services | grep NO
+        break
+    fi
+    if [ "$done" -ne 0 ]; then
+        echo "checking services loaded in $i seconds"
         break
     fi
   done

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source "${BASH_SOURCE%/*}/helpers_tests.bash"
+
 # use a clean instance of polycubed to run each test
 RELAUNCH_POLYCUBED=true
 
@@ -14,7 +16,7 @@ TEST_BRIDGE_STP=false
 # result.json path
 RESULT_JSON="result.json"
 
-declare -A services
+declare -A servicester
 services[ddosmitigator]=pcn-ddosmitigator
 services[firewall]=pcn-firewall
 services[helloworld]=pcn-helloworld
@@ -26,24 +28,6 @@ services[router]=pcn-router
 services[simplebridge]=pcn-simplebridge
 services[transparenthelloworld]=pcn-transparent-helloworld
 
-# cleanup environment before exit
-function cleanup {
-  set +e
-  echo "killing polycubed ..."
-  sudo pkill polycubed >> $test_tmp
-  echo "{ \"passed\":\"$test_passed\", \"total\":\"$test_total\", \"test_log\":\"$test_log\" }" > $RESULT_JSON
-
-  cat $test_results
-
-  echo ""
-  echo "FAILED TESTS:"
-  echo ""
-  cat $test_results | grep FAILED -A 1
-
-  if $failed ; then
-    exit 1
-  fi
-}
 trap cleanup EXIT
 
 # $1 setup RELAUNCH_POLYCUBED
@@ -81,175 +65,6 @@ echo "Tests Scripts - LOG FILE" > $test_log
 date >> $test_log
 echo >> $test_log
 
-# execute and log test ($1:path)
-function log_test {
-  "$@" >> $test_tmp 2>&1
-  local status=$?
-  last_test_result=$status
-
-  # check if polycubed is still alive (no crash in the meanwhile)
-  polycubed_alive=$(ps -el | grep polycubed)
-  if [ -z "$polycubed_alive" ]; then
-    echo "polycubed not running ..."
-    polycubed_crash=true
-    status=1
-  fi
-  test_total=$(($test_total+1))
-  if [ $status -ne 0 ]; then
-    echo "++++TEST $1 FAILED++++"
-    echo "++++TEST $1 FAILED++++" >> $test_results
-    echo "++++TEST $1 FAILED++++" >> $test_tmp
-    failed=true
-    cat $test_tmp >> $test_log
-  else
-    test_passed=$(($test_passed+1))
-    echo "++++TEST $1 PASSED++++"
-    echo "++++TEST $1 PASSED++++" >> $test_results
-    echo "++++TEST $1 PASSED++++" >> $test_tmp
-  fi
-  return $status
-}
-
-# Check if services are loaded
-function services_are_loaded {
-  echo "load_services:" > load_services
-  count=0
-  services_show=$(polycubectl services show)
-  for i in "${!services[@]}"
-  do
-    lines=$(echo $services_show | grep $i | wc -l)
-    if [ $lines -ne 0 ]
-    then
-      echo "$i YES" >> load_services
-    else
-      count=$((count + 1))
-      echo "$i NO" >> load_services
-    fi
-  done
-  echo $count
-}
-
-# Check if polycubed rest server is responding
-function polycubed_is_responding {
-  ret=$(polycubectl ? > /dev/null)
-  ret=$(echo $?)
-  echo $ret
-}
-
-# Kill polycubed, and wait all services to be unloaded and process to be completely killed
-function polycubed_kill_and_wait {
-  echo "killing polycubed ..."
-  sudo pkill polycubed >> $test_tmp
-
-  done=0
-  i=0
-  while : ; do
-    sleep 1
-    alive=$(ps -el | grep polycubed)
-    if [ -z "$alive" ]; then
-      done=1
-    fi
-
-    i=$((i+1))
-
-    if [ "$done" -ne 0 ]; then
-        echo "killing polycubed in $i seconds"
-        break
-    fi
-  done
-}
-
-# Relaunch polycubed, if deamon is not running
-function polycubed_relaunch_if_not_running {
-  alive=$(ps -el | grep polycubed)
-  if [ -z "$alive" ]; then
-    echo "polycubed not running ..."
-    echo "relaunching polycubed ..."
-    $polycubed >> $test_tmp 2>&1 &
-  fi
-}
-
-# Launch polycubed, and wait until it becomes responsive
-function launch_and_wait_polycubed_is_responding {
-  if $RELAUNCH_POLYCUBED; then
-    echo "starting polycubed ..."
-    $polycubed >> $test_tmp 2>&1 &
-  else
-    polycubed_alive=$(ps -el | grep polycubed)
-    if [ -z "$polycubed_alive" ]; then
-      echo "polycubed not running ..."
-      echo "relaunching polycubed ..."
-      $polycubed >> $test_tmp 2>&1 &
-    fi
-  fi
-
-  done=0
-  i=0
-  while : ; do
-    sleep 1
-    responding=$(polycubed_is_responding)
-    if [[ $responding -eq 0 ]]; then
-      done=1
-    else
-      polycubed_relaunch_if_not_running
-    fi
-    i=$((i+1))
-    if [ "$done" -ne 0 ]; then
-      if $RELAUNCH_POLYCUBED; then
-        echo "starting polycubed in $i seconds"
-      else
-        if [ -z "$polycubed_alive" ]; then
-          echo "relaunching polycubed in $i seconds"
-        fi
-      fi
-        break
-    fi
-  done
-
-  done=0
-  i=0
-  while : ; do
-    sleep 1
-    loaded=$(services_are_loaded)
-    if [[ $loaded -eq 0 ]]; then
-      done=1
-    fi
-
-    i=$((i+1))
-    if [ "$i" -eq $SERVICES_LOAD_TIMEOUT ]
-    then
-        echo "+ERROR+ timeout in checking services loaded $i seconds. try to run test anyway"
-        cat load_services | grep NO
-        break
-    fi
-    if [ "$done" -ne 0 ]; then
-        echo "checking services loaded in $i seconds"
-        break
-    fi
-  done
-}
-
-# run test ($1:path)
-function run_test {
-  polycubed_crash=false
-  STARTTIME=$(date +%s)
-  echo
-  echo "Starting test $1 ..."
-  echo "++++Starting test $1++++" > $test_tmp
-  launch_and_wait_polycubed_is_responding
-  echo "executing test ..."
-  log_test $1
-  if $RELAUNCH_POLYCUBED; then
-   polycubed_kill_and_wait
-  fi
-  echo "Finished test $1"
-  ENDTIME=$(date +%s)
-  echo "Time elapsed: $(($ENDTIME - $STARTTIME))s"
-  echo "Time elapsed: $(($ENDTIME - $STARTTIME))s" >> $test_results
-  echo "Time elapsed: $(($ENDTIME - $STARTTIME))s" >> $test_tmp
-  echo "++++Finished test $1++++" >> $test_tmp
-}
-
 function run_tests_from_dir {
   for test in $1test*.sh; do
     if [[ $test == *"test*.sh"* ]]; then
@@ -261,7 +76,6 @@ function run_tests_from_dir {
 }
 
 # Main script here
-
 echo "*scanning current dir for tests*"
 # ./test*.sh
 run_tests_from_dir ./


### PR DESCRIPTION
This commit introduces support for checking services to be
loaded before starting the tests.

From d8d280cd96a49ec4b6706e9ed3eef32c127c108f commit "Added new REST API and validation code", rest server is started [1] before services are loaded.
This introduces the possibility services are not yet loaded when polycubed is up and responsive and can cause tests to fail.

[1] https://github.com/polycube-network/polycube/blob/master/src/polycubed/src/polycubed.cpp#L276