### PR TITLE
polycubed: fix busy wait in netlink socket

### DIFF
--- a/src/polycubed/src/netlink.cpp
+++ b/src/polycubed/src/netlink.cpp
@@ -62,17 +62,19 @@ class Netlink::NetlinkNotification {
   }
 
   void execute_wait() {
-    int socket_fd, result;
+    int result;
     fd_set readset;
     struct timeval tv;
 
-    tv.tv_sec = NETLINK_TIMEOUT;
-    tv.tv_usec = 0;
-
     while (running) {
       do {
+        tv.tv_sec = NETLINK_TIMEOUT;
+        tv.tv_usec = 0;
         FD_ZERO(&readset);
         FD_SET(sock, &readset);
+        // The struct tv is decremented every time the select terminates.
+        // If the value is not updated, the next time select is called uses
+        // 0 as timeout value, behaving as a non-blocking socket.
         result = select(sock + 1, &readset, NULL, NULL, &tv);
       } while (result < 0 && errno == EINTR && running);
 


### PR DESCRIPTION
select() updates the timeout structure, so if this is not intialized it is
going to be 0 at some point and then create a busy wait loop, using 100% of a
cpu core.

This commit moves the assignent of the timeout structure to its original
location and adds the comment that was removed by mistake.
