### PR TITLE
pcn-nat: fix natting-tables show

### DIFF
--- a/src/services/pcn-nat/src/Nat_dp_common.c
+++ b/src/services/pcn-nat/src/Nat_dp_common.c
@@ -40,6 +40,14 @@
   (sizeof(struct eth_hdr) + sizeof(struct iphdr) + \
    offsetof(struct icmphdr, checksum))
 #define IS_PSEUDO 0x10
+
+/* __attribute__((packed))
+ * forces alignment for this structure;
+ * otherwise misaligned read/write could happen
+ * between userspace and kernel space.
+ * same attribute should be used in kernel/user space
+ * structs declaration.
+ */
 struct eth_hdr {
   __be64 dst : 48;
   __be64 src : 48;
@@ -52,9 +60,9 @@ struct st_k {
   uint16_t src_port;
   uint16_t dst_port;
   uint8_t proto;
-};
+} __attribute__((packed));
 struct st_v {
   uint32_t new_ip;
   uint16_t new_port;
   uint8_t originating_rule_type;
-};
+} __attribute__((packed));

--- a/src/services/pcn-nat/src/NattingTable.h
+++ b/src/services/pcn-nat/src/NattingTable.h
@@ -25,6 +25,14 @@ class Nat;
 using namespace io::swagger::server::model;
 
 /* definitions copied from datapath */
+
+/* __attribute__((packed))
+ * forces alignment for this structure;
+ * otherwise misaligned read/write could happen
+ * between userspace and kernel space.
+ * same attribute should be used in kernel/user space
+ * structs declaration.
+ */
 struct st_k {
   uint32_t src_ip;
   uint32_t dst_ip;


### PR DESCRIPTION
ensure st_k and st_v structs are aligned, using `__attribute__((packed))`.