### PR TITLE
load old topology at startup and save each modification to file

### DIFF
--- a/Documentation/polycubed/polycubed.rst
+++ b/Documentation/polycubed/polycubed.rst
@@ -59,14 +59,14 @@ If the same parameter is specified in both, the configuration file and the comma
 Persistency
 ^^^^^^^^^^^
 
-To add stateful capabilities and improve its reliability, polycubed has some functionalities that allow the user to recover from failures without losing data.
-By default, while running the daemon keeps in memory an instance of all the topology, that is updated each time the user modifies it.
-To avoid loss of data, after every change the cubes configuration is dumped to file too. The default path is ``/etc/polycube/cubes.yaml``.
-The standard behavior of the daemon at startup is to load the latest topology that have been dumped in that file the previous time.
-It is possible to define a different topology file by using the ``--cubes-dump`` flag followed by the path to the file.
-In the case we want to start polycubed with an empty topology, avoiding any possible load at startup, we can add the ``--cubes-init`` flag.
-Beware of the fact that any previous configuration in the file will be overwritten after the first modification.
-If not necessary, it is also possible to disable this functionality by using the ``--cubes-nodump`` flag and we would avoid any penalty it could produce.
+Polycubed has persistent capabilities, which means that (1) it can automatically load the configuration that was present when the daemon was shut down, (2) each time a configuration command is issued, it is automatically dumped on disk.
+This enables polycubed also to recover from failures, such as rebooting the machine.
+By default, the daemon keeps in memory an instance of all the topology, including the configuration of each individual service.
+Topology and configuration are automatically updated at each new command; the configuration is also dumped to disk, on file ``/etc/polycube/cubes.yaml``.
+The standard behavior of the daemon at startup is to load the latest topology that was active at the end of the previous execution.
+Users can load a different topology file by using the ``--cubes-dump`` flag followed by the path to the file.
+In case we want to start polycubed with an empty topology, avoiding any possible load at startup, we can launch polycubed with the ``--cubes-init`` flag. Beware that in this case any existing configuration in the default file will be overwritten.
+Finally, persistency can be disabled with the ``--cubes-nodump`` flag; this would also avoid any (very limited) performance penalty introduced by this feature.
 
 ::
 

--- a/src/libs/polycube/include/polycube/services/cube.h
+++ b/src/libs/polycube/include/polycube/services/cube.h
@@ -120,6 +120,19 @@ std::shared_ptr<PortType> Cube<PortType>::add_port(const std::string &port_name,
 
     std::tie(iter, inserted) = ports_by_name_.emplace(port_name, port);
     ports_by_id_.emplace(port->index(), port);
+    /*
+     * When a transparent cube is attached to a port, it can query the service
+     * to get some port parameters (e.g., MAC address). If the transparent cube
+     * is attached while the port is being created these parameters will be not
+     * configured yet.
+     * This workaround first creates the port and then passes the configuration
+     * to attach the transparent cubes. The configuration that is passed
+     * in the constructor is ignored in the daemon.
+     * The solution for this workaround would be to implement the notification
+     * mechanishm, so when the parameters are configured those are pushed to the
+     * transparent cube.
+     */
+    port->set_conf(conf.getBase());
     return iter->second;
   } catch (const std::exception &ex) {
     cube_->remove_port(port_name);

--- a/src/polycubed/src/CMakeLists.txt
+++ b/src/polycubed/src/CMakeLists.txt
@@ -62,6 +62,7 @@ set(polycubed_sources
   utils/veth.cpp
   utils/netlink.cpp
   utils/utils.cpp
+  cubes_dump.cpp
   ${server_sources}
   ${CMAKE_CURRENT_BINARY_DIR}/load_services.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/version.cpp)

--- a/src/polycubed/src/base_model.cpp
+++ b/src/polycubed/src/base_model.cpp
@@ -244,4 +244,24 @@ Response BaseModel::set_span(const std::string &cube_name,
   return Response{kOk, ::strdup("")};
 }
 
+Response BaseModel::get_port_tcubes(const std::string &cube_name,
+                                    const std::string &port_name) const {
+  auto cube_ = ServiceController::get_cube(cube_name);
+  if (cube_ == nullptr) {
+    return Response{kNoContent, ::strdup("Cube does not exist")};
+  }
+
+  // TODO: is this case even possible?
+  auto cube = std::dynamic_pointer_cast<CubeIface>(cube_);
+  if (cube == nullptr) {
+    return Response{kNoContent, ::strdup("Cube is transparent")};
+  }
+
+  auto port_ = cube->get_port(port_name);
+  auto port = std::dynamic_pointer_cast<Port>(port_);
+  nlohmann::json j = port->get_cubes_names();
+
+  return Response{kOk, ::strdup(j.dump().c_str())};
+}
+
 }  // namespace polycube::polycubed

--- a/src/polycubed/src/base_model.h
+++ b/src/polycubed/src/base_model.h
@@ -50,6 +50,8 @@ class BaseModel {
   Response get_span(const std::string &cube_name) const;
   Response set_span(const std::string &cube_name,
                       const nlohmann::json &json);
+  Response get_port_tcubes(const std::string &cube_name,
+                           const std::string &port_name) const;
 };
 
 }  // namespace polycube::polycubed

--- a/src/polycubed/src/config.cpp
+++ b/src/polycubed/src/config.cpp
@@ -32,13 +32,17 @@ namespace configuration {
 
 #define LOGLEVEL spdlog::level::level_enum::info
 #define DAEMON false
+#define CUBESINIT false
+#define CUBESNODUMP false
 #define PIDFILE "/var/run/polycube.pid"
 #define SERVER_PORT 9000
 #define SERVER_IP "localhost"
 #define LOGFILE "/var/log/polycube/polycubed.log"
 #define CONFIGFILEDIR "/etc/polycube"
 #define CONFIGFILENAME "polycubed.conf"
+#define CUBESDUMPFILE "cubes.yaml"
 #define CONFIGFILE (CONFIGFILEDIR "/" CONFIGFILENAME)
+#define CUBESDUMPFILEPATH (CONFIGFILEDIR "/" CUBESDUMPFILE)
 
 static void show_usage(const std::string &name) {
   std::cout << std::boolalpha;
@@ -64,6 +68,11 @@ static void show_usage(const std::string &name) {
             << ")" << std::endl;
   std::cout << "--configfile: configuration file (default: " << CONFIGFILE
             << ")" << std::endl;
+  std::cout << "--cubes-dump: file that keeps the last topology, "
+               "including the configuration of all cubes (default: " << CUBESDUMPFILEPATH
+            << ")" << std::endl;
+  std::cout << "--cubes-init: starts the daemon with an empty topology" << std::endl;
+  std::cout << "--cubes-nodump: starts the daemon without dumping updates to file" << std::endl;
   std::cout << "--cert-blacklist: path to black listed certificates"
             << std::endl;
   std::cout << "--cert-whitelist: path to white listed certificates"
@@ -95,7 +104,10 @@ Config::Config()
       server_port(SERVER_PORT),
       server_ip(SERVER_IP),
       logfile(LOGFILE),
-      configfile(CONFIGFILE) {}
+      configfile(CONFIGFILE),
+      cubes_dump_file(CUBESDUMPFILEPATH),
+      cubes_init(CUBESINIT),
+      cubes_nodump(CUBESNODUMP){}
 
 Config::~Config() {}
 
@@ -180,6 +192,31 @@ void Config::setLogFile(const std::string &value) {
   logfile = value;
 }
 
+std::string Config::getCubesDumpFilePath() const {
+  return cubes_dump_file;
+}
+
+void Config::setCubesDumpFilePath(const std::string &value) {
+  CHECK_OVERWRITE("cubes-dump", value, cubes_dump_file, CUBESDUMPFILEPATH);
+  cubes_dump_file = value;
+}
+
+bool Config::getCubesInitTopology() const {
+  return cubes_init;
+}
+
+void Config::setCubesInitTopology() {
+  cubes_init = true;
+}
+
+bool Config::getCubesNoDump() const {
+  return cubes_nodump;
+}
+
+void Config::setCubesNoDump() {
+  cubes_nodump = true;
+}
+
 std::string Config::getCertPath() const {
   return cert_path;
 }
@@ -246,6 +283,8 @@ void Config::create_configuration_file(const std::string &path) {
   file << "addr: " << server_ip << std::endl;
   file << "# file to save polycube logs" << std::endl;
   file << "logfile: " << logfile << std::endl;
+  file << "# file to save last topology" << std::endl;
+  file << "cubes-dump: " << cubes_dump_file << std::endl;
   file << "# Security related:" << std::endl;
   file << "# server certificate " << std::endl;
   file << "#cert: path_to_certificate_file" << std::endl;
@@ -270,6 +309,9 @@ void Config::dump() {
   logger->info(" port: {}", server_port);
   logger->info(" addr: {}", server_ip);
   logger->info(" logfile: {}", logfile);
+  logger->info(" cubes-dump: {}", cubes_dump_file);
+  logger->info(" cubes-init: {}", cubes_init);
+  logger->info(" cubes-nodump: {}", cubes_nodump);
   if (!cert_path.empty()) {
     logger->info(" cert: {}", cert_path);
   }
@@ -363,6 +405,9 @@ static struct option options[] = {
     {"cacert", required_argument, NULL, 5},
     {"cert-whitelist", required_argument, NULL, 6},
     {"cert-blacklist", required_argument, NULL, 7},
+    {"cubes-dump", required_argument, NULL, 8},
+    {"cubes-init", no_argument, NULL, 9},
+    {"cubes-nodump", no_argument, NULL, 10},
     {NULL, 0, NULL, 0},
 };
 
@@ -407,6 +452,15 @@ void Config::load_from_cli(int argc, char *argv[]) {
       break;
     case 7:
       setCertBlacklistPath(optarg);
+      break;
+    case 8:
+      setCubesDumpFilePath(optarg);
+      break;
+    case 9:
+      setCubesInitTopology();
+      break;
+    case 10:
+      setCubesNoDump();
       break;
     }
   }

--- a/src/polycubed/src/config.h
+++ b/src/polycubed/src/config.h
@@ -53,6 +53,18 @@ class Config {
   std::string getLogFile() const;
   void setLogFile(const std::string &value);
 
+  // file where last topology is saved
+  std::string getCubesDumpFilePath() const;
+  void setCubesDumpFilePath(const std::string &value);
+
+  // set to get an empty topology
+  bool getCubesInitTopology() const;
+  void setCubesInitTopology();
+
+  // set to avoid daemon to dump updates to file
+  bool getCubesNoDump() const;
+  void setCubesNoDump();
+
   // path of certificate & key to be used in server
   std::string getCertPath() const;
   void setCertPath(const std::string &value);
@@ -80,11 +92,14 @@ class Config {
 
   spdlog::level::level_enum loglevel;
   bool daemon;
+  bool cubes_init;
+  bool cubes_nodump;
   std::string pidfile;
   uint16_t server_port;
   std::string server_ip;
   std::string logfile;
   std::string configfile;
+  std::string cubes_dump_file;
   std::string cert_path, key_path;
   std::string cacert_path;
   std::string cert_whitelist_path;

--- a/src/polycubed/src/cubes_dump.cpp
+++ b/src/polycubed/src/cubes_dump.cpp
@@ -1,0 +1,411 @@
+/*
+ * Copyright 2019 The Polycube Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fstream>
+#include "cubes_dump.h"
+#include "config.h"
+#include "rest_server.h"
+#include "server/Resources/Body/ListKey.h"
+#include "server/Resources/Endpoint/Resource.h"
+
+namespace polycube::polycubed {
+
+using Rest::Resources::Body::ListKey;
+using Rest::Resources::Endpoint::Operation;
+
+CubesDump::CubesDump() : dump_enabled_(false), killSavingThread_(false) {
+  save_in_file_thread_ = std::make_unique<std::thread>(&CubesDump::SaveToFile, this, configuration::config.getCubesDumpFilePath());
+}
+
+CubesDump::~CubesDump() {
+  killSavingThread_ = true;
+  waitForUpdate_.notify_one();
+  save_in_file_thread_->join();
+}
+
+void CubesDump::Enable() {
+  dump_enabled_ = true;
+}
+
+void CubesDump::UpdateCubesConfig(const std::string& resource,
+                                  const nlohmann::json& body,
+                                  const ListKeyValues &keys,
+                                  Rest::Resources::Endpoint::Operation opType,
+                                  Rest::Resources::Endpoint::ResourceType resType) {
+
+  // TODO: remove this check
+  if (configuration::config.getCubesNoDump()) {
+    return;
+  }
+
+  std::string resourcePath = resource.substr(RestServer::base.size(), resource.size());
+
+  std::stringstream ssResource(resourcePath);
+  std::vector<std::string> resItem;
+  std::string tokenResource;
+
+  while (std::getline(ssResource, tokenResource, '/')) { /* Get path elements */
+    resItem.push_back(tokenResource);
+  }
+
+  /*
+   * Depending on the operation, we look into the resource string, the body
+   * and the ListKeyValues to update the configuration of the cubes in the map
+   * (<cubeName, cubeConfiguration>) we have in memory.
+   * If it is not the initial topology load, the whole configuration is saved
+   * to file after each modification by a separate thread, to avoid to overload
+   * the server thread.
+   */
+  std::lock_guard<std::mutex> guardConfigMutex(cubesConfigMutex_);
+  switch (opType) {
+  case Operation::kCreate:
+  case Operation::kReplace:
+    UpdateCubesConfigCreateReplace(resItem, body, keys, resType);
+    break;
+
+  case Operation::kUpdate:
+    UpdateCubesConfigUpdate(resItem, body, keys, resType);
+    break;
+
+  case Operation::kDelete:
+    UpdateCubesConfigDelete(resItem, body, keys, resType);
+    break;
+  }
+
+  /*
+   * if the dump is enabled, notify the saving thread that an update
+   * to the topology occured and needs to be dumped to file
+   */
+  if (dump_enabled_) {
+    listOfPendingChanges_++;
+    waitForUpdate_.notify_one();
+  }
+}
+
+/*
+ * This updates the configuration when the connect or disconnect special commands
+ * are used, setting another cube's port as peer for a certain cube.
+ */
+void CubesDump::UpdatePortPeer(const std::string& cubeName, const std::string& cubePort, std::string peer) {
+
+  // TODO: remove this check
+  if (configuration::config.getCubesNoDump()) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> guardConfigMutex(cubesConfigMutex_);
+  auto *cubePortsArray = &(cubesConfig_.at(cubeName).at("ports"));
+  auto *portToConnect = &*(std::find_if(cubePortsArray->begin(), cubePortsArray->end(),
+          [cubePort](auto const& elem){return elem.at("name") == cubePort;}));
+  if (peer.empty()) {
+    portToConnect->erase("peer");
+  } else {
+    nlohmann::json jsonPeer = nlohmann::json::object();
+    jsonPeer["peer"] = peer;
+    jsonPeer.update(*portToConnect);
+    portToConnect->clear();
+    portToConnect->update(jsonPeer);
+  }
+
+  /*
+   * if the dump is enabled, notify the saving thread that an update
+   * to the topology occured and needs to be dumped to file
+   */
+  if (dump_enabled_) {
+    listOfPendingChanges_++;
+    waitForUpdate_.notify_one();
+  }
+}
+
+/*
+ * This updates the configuration when the attach or detach special commands
+ * are used, adding or removing transparent cubes from other cubes' ports.
+ */
+void CubesDump::UpdatePortTCubes(const std::string& cubeName,
+                                 const std::string& cubePort,
+                                 std::string tCubeName,
+                                 int position) {
+
+  // TODO: remove this check
+  if (configuration::config.getCubesNoDump()) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> guardConfigMutex(cubesConfigMutex_);
+  auto *cubePortsArray = &(cubesConfig_.at(cubeName).at("ports"));
+  auto *interestedPort = &*(std::find_if(cubePortsArray->begin(), cubePortsArray->end(),
+                                        [cubePort](auto const& elem){return elem.at("name") == cubePort;}));
+  if (position == -1) {
+    auto toDetach = std::find(interestedPort->at("tcubes").begin(), interestedPort->at("tcubes").end(), tCubeName);
+    interestedPort->at("tcubes").erase(toDetach);
+    if (interestedPort->at("tcubes").empty()) {
+      interestedPort->erase("tcubes");
+    }
+  } else {
+    nlohmann::json element; /* workaround to bypass nlohmann::json library bug */
+    element.update(*interestedPort);
+    if (element["tcubes"].is_null()) {
+      std::vector<std::string> tCubesArray;
+      tCubesArray.push_back(tCubeName);
+      nlohmann::json completeObject = nlohmann::json::object();
+      completeObject["tcubes"] = tCubesArray;
+      completeObject.update(*interestedPort);
+      interestedPort->clear();
+      interestedPort->update(completeObject);
+    } else {
+      interestedPort->at("tcubes").insert(interestedPort->at("tcubes").begin() + position, tCubeName);
+    }
+  }
+
+  /*
+   * if the dump is enabled, notify the saving thread that an update
+   * to the topology occured and needs to be dumped to file
+   */
+  if (dump_enabled_) {
+    listOfPendingChanges_++;
+    waitForUpdate_.notify_one();
+  }
+}
+
+/*
+ * This adds or replaces a cube or a cube's resource
+ */
+void CubesDump::UpdateCubesConfigCreateReplace(const std::vector<std::string> &resItem,
+                                               const nlohmann::json& body,
+                                               const ListKeyValues &keys,
+                                               Rest::Resources::Endpoint::ResourceType resType) {
+
+  const std::string &serviceName = resItem[0];
+  const std::string &cubeName = resItem[1];
+
+  // map saving key values corresponding to proper list name
+  std::map<std::string, std::vector<Rest::Resources::Body::ListKeyValue>> keyValues;
+  for (auto &key : keys) {
+    keyValues[key.list_element].push_back(key);
+  }
+
+  switch (resType) {
+    case Rest::Resources::Endpoint::ResourceType::Service: {
+      nlohmann::json serviceField = nlohmann::json::object();
+      serviceField["service-name"] = serviceName;
+      serviceField.update(body);
+      if (cubesConfig_.find(cubeName) != cubesConfig_.end()) { /* If it is a replacement, delete it first */
+        cubesConfig_.at(cubeName).clear();
+      }
+      cubesConfig_[cubeName].update(serviceField);
+      break;
+    }
+
+    case Rest::Resources::Endpoint::ResourceType::ParentResource:
+    case Rest::Resources::Endpoint::ResourceType::ListResource: {
+      nlohmann::json *item = &cubesConfig_[cubeName];
+      for (int i = 2; i < resItem.size() - 1; i++) {
+        nlohmann::json element; /* workaround to bypass nlohmann::json library bug */
+        element.update(*item);
+        auto *reference = &(*item)[resItem[i]];
+        if (element[resItem[i]].is_null()) { /* is element present? */
+          if (!keys.empty() && keyValues.find(resItem[i]) != keyValues.end()) { /* is it a missing array? */
+            nlohmann::json toUpdate = nlohmann::json::array();
+            toUpdate.push_back(body);
+            nlohmann::json completeObj;
+            completeObj[resItem[i]] = toUpdate;
+            element.update(completeObj);
+            *item = element;
+            break;
+          }
+        } else if (element[resItem[i]].is_array()) { /* is it an array? */
+          auto toCreateReplace = std::find_if(reference->begin(), reference->end(),
+                  [resItem, i, keyValues, this](auto const& elem){return checkPresence(resItem, i, keyValues, elem);});
+          i += keyValues.at(resItem[i]).size();
+          if (i > resItem.size() - 2) { /* if it is an element of an array and it is the last, we can update it */
+            if (toCreateReplace != reference->end()) {
+              reference->erase(toCreateReplace);
+            }
+            reference->push_back(body);
+          } else { /* not the last, find the element and update the reference */
+            reference = &*toCreateReplace;
+          }
+        }
+        item = reference;
+      }
+      break;
+    }
+
+    case Rest::Resources::Endpoint::ResourceType::LeafResource: {
+      nlohmann::json *item = &cubesConfig_[cubeName];
+      for (int i = 2; i < resItem.size() - 1; i++) {
+        auto *reference = &(*item)[resItem[i]];
+        if (reference->is_array()) { /* find the array element and update the reference */
+          reference = &*(std::find_if(reference->begin(), reference->end(),
+                  [resItem, i, keyValues, this](auto const& elem){return checkPresence(resItem, i, keyValues, elem);}));
+          i += keyValues.at(resItem[i]).size();
+        } else if (i > resItem.size() - 2) {
+          nlohmann::json toUpdate = nlohmann::json::object();
+          toUpdate[resItem[resItem.size() - 1]] = body;
+          toUpdate.insert(item->begin(), item->end());
+          item->clear();
+          item->update(toUpdate);
+        }
+        item = reference;
+      }
+      break;
+    }
+  }
+}
+
+/*
+ * This updates a cube or a cube's resource.
+ */
+void CubesDump::UpdateCubesConfigUpdate(const std::vector<std::string> &resItem,
+                                        const nlohmann::json body,
+                                        const ListKeyValues &keys,
+                                        Rest::Resources::Endpoint::ResourceType resType) {
+
+  const std::string &serviceName = resItem[0];
+  const std::string &cubeName = resItem[1];
+
+  std::map<std::string, std::vector<Rest::Resources::Body::ListKeyValue>> keyValues;
+  for (auto &key : keys) {
+    keyValues[key.list_element].push_back(key);
+  }
+
+  if (resType == Rest::Resources::Endpoint::ResourceType::Service) {
+    nlohmann::json serviceField = nlohmann::json::object();
+    serviceField.update(body);
+    cubesConfig_.at(cubeName).update(serviceField);
+  } else {
+    nlohmann::json *item = &cubesConfig_[cubeName];
+    for (int i = 2; i < resItem.size() - 1; i++) {
+      auto *reference = &(*item)[resItem[i]];
+      if (reference->is_array()) { /* If it is an array corresponding to a key, then it is an element of an array */
+        reference = &*(std::find_if(reference->begin(), reference->end(),
+                [resItem, i, keyValues, this](auto const& elem){return checkPresence(resItem, i, keyValues, elem);}));
+        i += keyValues.at(resItem[i]).size();
+      }
+      item = reference;
+    }
+
+    nlohmann::json toUpdate = nlohmann::json::object();
+    toUpdate[resItem[resItem.size() - 1]] = body;
+    toUpdate.insert(item->begin(), item->end());
+    item->clear();
+    item->update(toUpdate);
+  }
+}
+
+/*
+ * This deletes a cube or a cube's resource.
+ */
+void CubesDump::UpdateCubesConfigDelete(const std::vector<std::string> &resItem,
+                                        const nlohmann::json& body,
+                                        const ListKeyValues &keys,
+                                        Rest::Resources::Endpoint::ResourceType resType) {
+
+  const std::string &serviceName = resItem[0];
+  const std::string &cubeName = resItem[1];
+
+  std::map<std::string, std::vector<Rest::Resources::Body::ListKeyValue>> keyValues;
+  for (auto &key : keys) {
+    keyValues[key.list_element].push_back(key);
+  }
+
+  if (resType == Rest::Resources::Endpoint::ResourceType::Service) { /* If it regards the full service */
+    cubesConfig_.erase(cubeName);
+  } else { /* If it regards an element of that service */
+    nlohmann::json *item = &cubesConfig_[cubeName];
+    bool deleted = false;
+    for (int i = 2; i < resItem.size() - 1; i++) {
+      auto *reference = &(*item)[resItem[i]];
+      if (reference->is_array()) { /* If it is an element of an array, treat it differently */
+        int actualIndex = i;
+        auto toDelete = std::find_if(reference->begin(), reference->end(),
+                [resItem, i, keyValues, this](auto const& elem){return checkPresence(resItem, i, keyValues, elem);});
+        i += keyValues.at(resItem[i]).size();
+        if (i > resItem.size() - 2) { /* if it is an array element, delete it now and set deleted true */
+          reference->erase(toDelete);
+          deleted = true;
+          if (reference->empty()) { /* delete if array is empty */
+            item->erase(resItem[actualIndex]);
+          }
+        } else { /* update the reference to the array elem */
+          reference = &*toDelete;
+        }
+      }
+      item = reference;
+    }
+
+    if (!deleted) {
+      item->erase(resItem[resItem.size() - 1]);
+    }
+  }
+}
+
+/*
+ * This function is called in a thread when the cube-dump option is enabled
+ */
+void CubesDump::SaveToFile(const std::string& path) {
+  while (true) {
+    // mutex with condition variable waitForUpdate on cubesConfig_
+    std::unique_lock<std::mutex> cubesConfigLock(cubesConfigMutex_);
+    // retrieve the value of the atomic variable and if there are no updates from last write to file,
+    // either wait for updates (kill=false) or exit if the daemon is shutting down (kill=true)
+    if (listOfPendingChanges_.load() == 0 && !killSavingThread_) {
+      waitForUpdate_.wait(cubesConfigLock);
+    }
+
+    if (listOfPendingChanges_.load() == 0 && killSavingThread_) {
+      break;
+    }
+
+    std::map<std::string, nlohmann::json> copyConfig(cubesConfig_);
+    // reset to 0 the list of pending changes
+    listOfPendingChanges_.store(0);
+    cubesConfigLock.unlock();
+    std::ofstream cubesDump(path);
+
+    if (cubesDump.is_open()) {
+      nlohmann::json toDump = nlohmann::json::array();
+      for (const auto &elem : copyConfig) {
+        auto cube = elem.second;
+        toDump += cube;
+      }
+      cubesDump << toDump.dump(2);
+      cubesDump.close();
+    }
+  }
+}
+
+/*
+ * checks if an element with certain key values exists
+ */
+bool CubesDump::checkPresence(const std::vector<std::string> &resItem,
+                              const int &resItemIndex,
+                              const std::map<std::string, std::vector<Rest::Resources::Body::ListKeyValue>> &keyValues,
+                              const nlohmann::json &elem) {
+  int valuesNumber = keyValues.at(resItem[resItemIndex]).size();
+  int index = 0;
+
+  for (auto &element : keyValues.at(resItem[resItemIndex])) {
+    if (std::string(elem[keyValues.at(resItem[resItemIndex])[index].original_key]) == resItem[resItemIndex + index + 1]) {
+      valuesNumber--;
+      index++;
+    }
+  }
+
+  return valuesNumber == 0;
+}
+
+} // namespace polycube::polycubed

--- a/src/polycubed/src/cubes_dump.h
+++ b/src/polycubed/src/cubes_dump.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 The Polycube Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <polycube/services/json.hpp>
+#include <server/Resources/Body/ListKey.h>
+#include <server/Resources/Endpoint/Resource.h>
+
+namespace polycube::polycubed {
+
+class CubesDump {
+ public:
+  CubesDump();
+  ~CubesDump();
+
+  void Enable();
+
+  void UpdateCubesConfig(const std::string &resource,
+                         const nlohmann::json &body,
+                         const ListKeyValues &keys,
+                         Rest::Resources::Endpoint::Operation opType,
+                         Rest::Resources::Endpoint::ResourceType resType);
+
+  void UpdatePortPeer(const std::string& cubeName, const std::string& cubePort, std::string peer);
+
+  void UpdatePortTCubes(const std::string& cubeName, const std::string& cubePort, std::string tCubeName, int position);
+
+ private:
+  void UpdateCubesConfigCreateReplace(const std::vector<std::string> &resItem,
+                                      const nlohmann::json &body,
+                                      const ListKeyValues &keys,
+                                      Rest::Resources::Endpoint::ResourceType resType);
+
+  void UpdateCubesConfigUpdate(const std::vector<std::string> &resItem,
+                               const nlohmann::json body,
+                               const ListKeyValues &keys,
+                               Rest::Resources::Endpoint::ResourceType resType);
+
+  void UpdateCubesConfigDelete(const std::vector<std::string> &resItem,
+                               const nlohmann::json &body,
+                               const ListKeyValues &keys,
+                               Rest::Resources::Endpoint::ResourceType resType);
+
+  bool checkPresence(const std::vector<std::string> &resItem,
+                     const int &resItemIndex,
+                     const std::map<std::string, std::vector<Rest::Resources::Body::ListKeyValue>> &keyValues,
+                     const nlohmann::json &elem);
+
+  void SaveToFile(const std::string &path);
+
+  // thread that saves in file
+  std::unique_ptr<std::thread> save_in_file_thread_;
+  // mutex on the access to cubesConfig
+  std::mutex cubesConfigMutex_;
+  // cubes configuration <name, configuration>
+  std::map<std::string, nlohmann::json> cubesConfig_;
+  // how many updates have been made while thread saving to file.
+  // it is incremented by the server to notify when an update is available while
+  // the saving thread was not waiting on the condition_variable
+  std::atomic<int> listOfPendingChanges_;
+  // wait until an update occurs
+  std::condition_variable waitForUpdate_;
+  // the saving thread ends if the daemon is shutting down (kill=true)
+  bool killSavingThread_;
+  bool dump_enabled_;
+};
+} // namespace polycube::polycubed

--- a/src/polycubed/src/peer_iface.cpp
+++ b/src/polycubed/src/peer_iface.cpp
@@ -111,6 +111,18 @@ void PeerIface::remove_cube(const std::string &cube_name) {
   update_indexes();
 }
 
+std::vector<std::string> PeerIface::get_cubes_names() const {
+  std::lock_guard<std::mutex> guard(mutex_);
+
+  std::vector<std::string> cubes_names;
+
+  for (auto &cube : cubes_) {
+    cubes_names.push_back(cube->get_name());
+  }
+
+  return cubes_names;
+}
+
 PeerIface::CubePositionComparison PeerIface::compare_position(
     const std::string &cube1, const std::string &cube2) {
   // cube position, index 0 is the innermost one

--- a/src/polycubed/src/peer_iface.cpp
+++ b/src/polycubed/src/peer_iface.cpp
@@ -33,7 +33,7 @@ int PeerIface::calculate_cube_index(int index) {
 
 enum class Position { AUTO, FIRST, LAST };
 
-void PeerIface::add_cube(TransparentCube *cube, const std::string &position,
+void PeerIface::add_cube(TransparentCube *cube, std::string *position,
                          const std::string &other) {
   std::lock_guard<std::mutex> guard(mutex_);
   int index = 0;
@@ -51,7 +51,7 @@ void PeerIface::add_cube(TransparentCube *cube, const std::string &position,
     }
   }
 
-  if (position == "auto") {
+  if (*position == "auto") {
     CubePositionComparison cmp;
     // try to determine index from below
     for (int i = 0; i < cubes_.size(); i++) {
@@ -80,16 +80,17 @@ void PeerIface::add_cube(TransparentCube *cube, const std::string &position,
         }
       }
     }
-  } else if (position == "first") {
+  } else if (*position == "first") {
     index = 0;
-  } else if (position == "last") {
+  } else if (*position == "last") {
     index = cubes_.size();
-  } else if (position == "before") {
+  } else if (*position == "before") {
     index = other_index;
-  } else if (position == "after") {
+  } else if (*position == "after") {
     index = other_index + 1;
   }
 
+  *position = std::to_string(index);
   cubes_.insert(cubes_.begin() + calculate_cube_index(index), cube);
   update_indexes();
 }

--- a/src/polycubed/src/peer_iface.h
+++ b/src/polycubed/src/peer_iface.h
@@ -43,6 +43,7 @@ class PeerIface {
   void add_cube(TransparentCube *cube, const std::string &position,
                 const std::string &other);
   void remove_cube(const std::string &type);
+  std::vector<std::string> get_cubes_names() const;
 
  protected:
   enum class CubePositionComparison {

--- a/src/polycubed/src/peer_iface.h
+++ b/src/polycubed/src/peer_iface.h
@@ -40,7 +40,7 @@ class PeerIface {
 
   virtual std::string get_parameter(const std::string &parameter) = 0;
 
-  void add_cube(TransparentCube *cube, const std::string &position,
+  void add_cube(TransparentCube *cube, std::string *position,
                 const std::string &other);
   void remove_cube(const std::string &type);
   std::vector<std::string> get_cubes_names() const;

--- a/src/polycubed/src/polycubed.cpp
+++ b/src/polycubed/src/polycubed.cpp
@@ -37,6 +37,7 @@
 #include <spdlog/sinks/stdout_sinks.h>
 
 #include "polycubed_core.h"
+#include "cubes_dump.h"
 
 #define REQUIRED_POLYCUBED_KERNEL ("4.14.0")
 
@@ -54,6 +55,7 @@ std::shared_ptr<spdlog::logger> logger;
 // create core instance
 PolycubedCore *core;
 RestServer *restserver;
+CubesDump *cubesdump;
 int netlink_notification_id = -1;
 
 void shutdown() {
@@ -68,6 +70,10 @@ void shutdown() {
     logger->debug("rest server shutdown");
     delete core;
     delete restserver;
+  }
+
+  if (cubesdump) {
+    delete cubesdump;
   }
 
   if (netlink_notification_id != -1) {
@@ -277,6 +283,23 @@ int main(int argc, char *argv[]) {
 
   // register services that are shipped with polycube
   load_services(*core);
+
+  // create a cubes dump instance if needed
+  if (!config.getCubesNoDump()) {
+    cubesdump = new CubesDump();
+    core->set_cubes_dump(cubesdump);
+  }
+
+  // In case the user does not want to initialize the Polycube virtual network,
+  // let's load the last topology that was present when the daemon was shut down.
+  if (!config.getCubesInitTopology()) {
+    restserver->load_last_topology();
+  }
+
+  if (!config.getCubesNoDump()) {
+    // start to saving topology only after it has been loaded
+    cubesdump->Enable();
+  }
 
   // pause the execution of current thread until ctrl+c
   pause();

--- a/src/polycubed/src/polycubed_core.cpp
+++ b/src/polycubed/src/polycubed_core.cpp
@@ -378,8 +378,8 @@ void PolycubedCore::attach(const std::string &cube_name,
         ServiceController::ports_to_ifaces.at(port_name));
   }
 
-  cube->set_parent(peer.get());
   peer->add_cube(cube.get(), position, other);
+  cube->set_parent(peer.get());
 }
 
 void PolycubedCore::detach(const std::string &cube_name,

--- a/src/polycubed/src/polycubed_core.cpp
+++ b/src/polycubed/src/polycubed_core.cpp
@@ -343,7 +343,7 @@ void PolycubedCore::attach(const std::string &cube_name,
       }
       break;
     case PortType::XDP:
-      if (cube->get_type() != CubeType::XDP_DRV &&
+      if (cube->get_type() != CubeType::XDP_SKB &&
           cube->get_type() != CubeType::XDP_DRV) {
         throw std::runtime_error(cube_name + " and " + port_name +
                                  " have incompatible types");

--- a/src/polycubed/src/polycubed_core.cpp
+++ b/src/polycubed/src/polycubed_core.cpp
@@ -243,6 +243,8 @@ bool PolycubedCore::try_to_set_peer(const std::string &peer1,
     }
     auto port = cube->get_port(match[2]);
     port->set_peer(peer2);
+    // Update the peer of a port in the cubes configuration in memory
+    cubes_dump_->UpdatePortPeer(cube->get_name(), port->name(), peer2);
     return true;
   }
 
@@ -322,19 +324,21 @@ void PolycubedCore::attach(const std::string &cube_name,
 
   std::smatch match;
   std::regex rule("(\\S+):(\\S+)");
+  std::shared_ptr<CubeIface> cube2;
+  std::shared_ptr<PortIface> port;
 
   if (std::regex_match(port_name, match, rule)) {
     auto cube2_ = ServiceController::get_cube(match[1]);
     if (cube2_ == nullptr) {
       throw std::runtime_error("Port " + port_name + " does not exist");
     }
-    auto cube2 = std::dynamic_pointer_cast<CubeIface>(cube2_);
+    cube2 = std::dynamic_pointer_cast<CubeIface>(cube2_);
     if (!cube2) {
       throw std::runtime_error("Cube " + std::string(match[1]) +
                                " is transparent");
     }
 
-    auto port = cube2->get_port(match[2]);
+    port = cube2->get_port(match[2]);
     switch (port->get_type()) {
     case PortType::TC:
       if (cube->get_type() != CubeType::TC) {
@@ -378,8 +382,14 @@ void PolycubedCore::attach(const std::string &cube_name,
         ServiceController::ports_to_ifaces.at(port_name));
   }
 
-  peer->add_cube(cube.get(), position, other);
+  std::string insertPosition = position;
+  peer->add_cube(cube.get(), &insertPosition, other);
   cube->set_parent(peer.get());
+
+  // if it is a cube's transparent cube, add it to the cubes configuration in memory
+  if (!match.empty()) {
+    cubes_dump_->UpdatePortTCubes(cube2->get_name(), port->name(), cube_name, std::stoi(insertPosition));
+  }
 }
 
 void PolycubedCore::detach(const std::string &cube_name,
@@ -399,19 +409,21 @@ void PolycubedCore::detach(const std::string &cube_name,
 
   std::smatch match;
   std::regex rule("(\\S+):(\\S+)");
+  std::shared_ptr<CubeIface> cube2;
+  std::shared_ptr<PortIface> port;
 
   if (std::regex_match(port_name, match, rule)) {
     auto cube2_ = ServiceController::get_cube(match[1]);
     if (cube2_ == nullptr) {
       throw std::runtime_error("Port " + port_name + " does not exist");
     }
-    auto cube2 = std::dynamic_pointer_cast<CubeIface>(cube2_);
+    cube2 = std::dynamic_pointer_cast<CubeIface>(cube2_);
     if (!cube2) {
       throw std::runtime_error("Cube " + std::string(match[1]) +
                                " is transparent");
     }
 
-    auto port = cube2->get_port(match[2]);
+    port = cube2->get_port(match[2]);
     peer = std::dynamic_pointer_cast<PeerIface>(port);
     peer->remove_cube(cube->get_name());
   } else {
@@ -427,6 +439,10 @@ void PolycubedCore::detach(const std::string &cube_name,
   }
 
   cube->set_parent(nullptr);
+  // if it is a cube's transparent cube, remove it from the cubes configuration in memory
+  if (!match.empty()) {
+    cubes_dump_->UpdatePortTCubes(cube2->get_name(), port->name(), cube_name, -1);
+  }
 }
 
 std::string PolycubedCore::get_cube_port_parameter(
@@ -438,7 +454,7 @@ std::string PolycubedCore::get_cube_port_parameter(
   auto &ctrl = get_service_controller(service_name);
   auto res = ctrl.get_management_interface()->get_service()->Child("ports");
 
-  ListKeyValues k{{"ports_name", ListType::kString, port_name}};
+  ListKeyValues k{{"ports", "name", "ports_name", ListType::kString, port_name}};
 
   std::istringstream iss(port_name + "/" + parameter);
   for (std::string segment; std::getline(iss, segment, '/');) {
@@ -447,7 +463,7 @@ std::string PolycubedCore::get_cube_port_parameter(
       auto list = std::dynamic_pointer_cast<ListResource>(res);
       if (list != nullptr) {
         for (const auto &key : list->keys_) {
-          ListKeyValue v{key.Name(), key.Type(), segment};
+          ListKeyValue v{"ports", key.OriginalName(), key.Name(), key.Type(), segment};
           k.emplace_back(v);
           std::getline(iss, segment, '/');  // if null raise error
         }
@@ -506,6 +522,14 @@ RestServer *PolycubedCore::get_rest_server() {
 
 BaseModel *PolycubedCore::base_model() {
   return base_model_;
+}
+
+void PolycubedCore::set_cubes_dump(CubesDump *cubes_dump) {
+  cubes_dump_= cubes_dump;
+}
+
+CubesDump *PolycubedCore::get_cubes_dump() {
+  return cubes_dump_;
 }
 
 }  // namespace polycubed

--- a/src/polycubed/src/polycubed_core.h
+++ b/src/polycubed/src/polycubed_core.h
@@ -39,6 +39,7 @@ namespace polycubed {
 class RestServer;
 
 class PolycubedCore {
+  friend class RestServer;
  public:
   PolycubedCore(BaseModel *base_model);
   ~PolycubedCore();

--- a/src/polycubed/src/polycubed_core.h
+++ b/src/polycubed/src/polycubed_core.h
@@ -24,6 +24,7 @@
 #include <unordered_map>
 
 #include "base_model.h"
+#include "cubes_dump.h"
 #include "polycube/services/guid.h"
 #include "polycube/services/json.hpp"
 #include "service_controller.h"
@@ -83,6 +84,10 @@ class PolycubedCore {
 
   void set_rest_server(RestServer *rest_server);
   RestServer *get_rest_server();
+
+  void set_cubes_dump(CubesDump *cubes_dump);
+  CubesDump *get_cubes_dump();
+
   BaseModel *base_model();
 
  private:
@@ -93,6 +98,8 @@ class PolycubedCore {
   std::shared_ptr<spdlog::logger> logger;
   RestServer *rest_server_;
   BaseModel *base_model_;
+  // This manages the cubes configuration in memory and the dump to file
+  CubesDump *cubes_dump_;
 };
 
 }  // namespace polycubed

--- a/src/polycubed/src/port.cpp
+++ b/src/polycubed/src/port.cpp
@@ -163,6 +163,13 @@ void Port::set_conf(const nlohmann::json &conf) {
   if (conf.count("peer")) {
     set_peer(conf.at("peer").get<std::string>());
   }
+
+  // attach transparent cubes present on the port
+  if (conf.count("tcubes")) {
+    for (auto &cube : conf.at("tcubes")) {
+      core->attach(cube.get<std::string>(), get_path(), "last", "");
+    }
+  }
 }
 
 nlohmann::json Port::to_json() const {
@@ -172,6 +179,11 @@ nlohmann::json Port::to_json() const {
   val["uuid"] = uuid().str();
   val["status"] = port_status_to_string(get_status());
   val["peer"] = peer();
+
+  const auto &cubes_names = get_cubes_names();
+  if (cubes_names.size()) {
+    val["tcubes"] = cubes_names;
+  }
 
   return val;
 }

--- a/src/polycubed/src/rest_server.cpp
+++ b/src/polycubed/src/rest_server.cpp
@@ -17,6 +17,7 @@
 
 #include <string>
 #include <vector>
+#include <fstream>
 
 #include "polycubed_core.h"
 #include "service_controller.h"
@@ -26,12 +27,16 @@
 #include "polycube/services/response.h"
 #include "server/Resources/Data/AbstractFactory.h"
 #include "server/Server/ResponseGenerator.h"
+#include "config.h"
+#include "cubes_dump.h"
 
 namespace polycube {
 namespace polycubed {
 
 std::string RestServer::whitelist_cert_path;
 std::string RestServer::blacklist_cert_path;
+
+const std::string RestServer::base = "/polycube/v1/";
 
 // start http server for Management APIs
 // Incapsultate a core object // TODO probably there are best ways...
@@ -148,6 +153,59 @@ void RestServer::shutdown() {
   try {
     httpEndpoint_->shutdown();
   } catch (const std::runtime_error &e) {
+    logger->error("{0}", e.what());
+  }
+}
+
+void RestServer::create_cubes(json &cubes) {
+  /*
+   * This is possible that a cube's port has as peer another port
+   * of a cube that hasn't been created yet.  This logic removes all
+   * the peers from the request and sets them after all cubes have
+   * been created.
+   */
+  auto peers = utils::strip_port_peers(cubes);
+  std::vector<Response> resp = {{ErrorTag::kNoContent, nullptr}};
+  bool error = false;
+
+  for (auto &cube : cubes) {
+    auto &s = core.get_service_controller(cube["service-name"]);
+    auto res = s.get_management_interface()->get_service()
+            ->CreateReplaceUpdate(cube["name"], cube, false, true);
+
+    if (res.size() != 1 || res[0].error_tag != kCreated) {
+      std::string msg;
+      for (auto & r: res) {
+        //logger->debug("- {}", r.message);
+        msg += std::string(r.message) + " ";
+      }
+
+      throw std::runtime_error("Error creating cube: " + cube["name"].get<std::string>() + msg);
+    }
+  }
+
+  for (auto &[peer1, peer2] : peers) {
+    core.try_to_set_peer(peer1, peer2);
+  }
+}
+
+void RestServer::load_last_topology() {
+  logger->info("loading cubes from {}", configuration::config.getCubesDumpFilePath());
+  std::ifstream topologyFile(configuration::config.getCubesDumpFilePath());
+  if (!topologyFile.is_open()) {
+    logger->warn("error opening dump file: {}", configuration::config.getCubesDumpFilePath());
+    return;
+  }
+
+  std::stringstream buffer;
+  buffer << topologyFile.rdbuf();
+  topologyFile.close();
+  // parse the file and create and initialize each cube one by one
+  try {
+    json jcubes = json::parse(buffer.str());
+    logJson(jcubes);
+    create_cubes(jcubes);
+  } catch (const std::exception &e) {
     logger->error("{0}", e.what());
   }
 }
@@ -438,32 +496,7 @@ void RestServer::post_cubes(const Pistache::Rest::Request &request,
   try {
     json cubes = json::parse(request.body());
     logJson(cubes);
-    /*
-     * This is possible that a cube's port has as peer another port
-     * of a cube that hasn't been created yet.  This logic removes all
-     * the peers from the request and sets them after all cubes have
-     * been created.
-     */
-    auto peers = utils::strip_port_peers(cubes);
-    std::vector<Response> resp = {{ErrorTag::kNoContent, nullptr}};
-    bool error = false;
-
-    for (auto &cube : cubes) {
-      resp = core.get_service_controller(cube["service-name"]).get_management_interface()->get_service()
-              ->CreateReplaceUpdate(cube["name"], cube, false, true);
-      if (!error && resp[0].error_tag != kCreated) {
-        Rest::Server::ResponseGenerator::Generate(std::move(resp), std::move(response));
-        error = true;
-      }
-    }
-
-    if (!error) {
-      Rest::Server::ResponseGenerator::Generate(std::move(resp), std::move(response));
-    }
-
-    for (auto &[peer1, peer2] : peers) {
-      core.try_to_set_peer(peer1, peer2);
-    }
+    create_cubes(cubes);
   } catch (const std::runtime_error &e) {
     logger->error("{0}", e.what());
     response.send(Pistache::Http::Code::Bad_Request, e.what());

--- a/src/polycubed/src/rest_server.h
+++ b/src/polycubed/src/rest_server.h
@@ -50,7 +50,7 @@ class RestServer {
 
   std::shared_ptr<Pistache::Rest::Router> get_router();
 
-  const std::string base = "/polycube/v1/";
+  static const std::string base;
 
   void init(size_t thr = 1, const std::string &server_cert = "",
             const std::string &server_key = "",
@@ -60,6 +60,7 @@ class RestServer {
 
   void start();
   void shutdown();
+  void load_last_topology();
 
  private:
   void setup_routes();
@@ -85,8 +86,8 @@ class RestServer {
   void get_cube(const Pistache::Rest::Request &request,
                 Pistache::Http::ResponseWriter response);
 
-    void post_cubes(const Pistache::Rest::Request &request,
-                       Pistache::Http::ResponseWriter response);
+  void post_cubes(const Pistache::Rest::Request &request,
+                     Pistache::Http::ResponseWriter response);
 
   void cubes_help(const Pistache::Rest::Request &request,
                   Pistache::Http::ResponseWriter response);
@@ -129,6 +130,8 @@ class RestServer {
 
   void get_version(const Pistache::Rest::Request &request,
                    Pistache::Http::ResponseWriter response);
+
+  void create_cubes(json &cubes);
 
   void logRequest(const Pistache::Rest::Request &request);
   void logJson(json j);

--- a/src/polycubed/src/server/Parser/YangNodes.tcpp
+++ b/src/polycubed/src/server/Parser/YangNodes.tcpp
@@ -395,10 +395,13 @@ void Yang::ParseLeafList(
   }
   std::shared_ptr<Resources::Body::LeafListResource> resource;
   if (generate_endpoint) {
+    auto base_model = base_model_factory_->IsBaseModel(parsed_names);
+    auto &&factory__ = base_model ? dynamic_cast<Resources::Data::AbstractFactory*>(base_model_factory_.get()) : factory_.get();
+
     const auto &e_parent =
         std::dynamic_pointer_cast<Resources::Endpoint::ParentResource>(parent);
     auto endpoint = e_parent->Endpoint() + '/' + leaflist->name;
-    resource = factory_->RestLeafList(
+    resource = factory__->RestLeafList(
         std::move(parsed_names), leaflist->name, description, cli_example,
         endpoint, parent.get(), std::move(value_field), node_fields,
         configuration, init_only_config, mandatory,

--- a/src/polycubed/src/server/Resources/Body/ListKey.h
+++ b/src/polycubed/src/server/Resources/Body/ListKey.h
@@ -65,6 +65,8 @@ class ListKey {
 };
 
 struct ListKeyValue {
+  const std::string list_element;
+  const std::string original_key;
   const std::string &name;
   const ListType type;
   const std::string value;

--- a/src/polycubed/src/server/Resources/Data/BaseModel/CMakeLists.txt
+++ b/src/polycubed/src/server/Resources/Data/BaseModel/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(base_model_sources
         ${CMAKE_CURRENT_LIST_DIR}/ConcreteFactory.cpp
         ${CMAKE_CURRENT_LIST_DIR}/LeafResource.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/LeafListResource.cpp
         PARENT_SCOPE)

--- a/src/polycubed/src/server/Resources/Data/BaseModel/ConcreteFactory.cpp
+++ b/src/polycubed/src/server/Resources/Data/BaseModel/ConcreteFactory.cpp
@@ -22,11 +22,13 @@
 #include "../../Body/JsonNodeField.h"
 
 #include "../../Endpoint/LeafResource.h"
+#include "../../Endpoint/LeafListResource.h"
 #include "../../Endpoint/ListResource.h"
 #include "../../Endpoint/ParentResource.h"
 #include "../../Endpoint/Service.h"
 
 #include "LeafResource.h"
+#include "LeafListResource.h"
 
 #include "polycubed_core.h"
 
@@ -56,7 +58,7 @@ bool ConcreteFactory::IsBaseModel(
     tree_names_.pop();
     auto leaf = tree_names_.front();
 
-    if (leaf == "uuid" || leaf == "status" || leaf == "peer") {
+    if (leaf == "uuid" || leaf == "status" || leaf == "peer" || leaf == "tcubes") {
       return true;
     }
   }
@@ -228,8 +230,42 @@ std::unique_ptr<Endpoint::LeafListResource> ConcreteFactory::RestLeafList(
     const std::vector<Body::JsonNodeField> &node_fields, bool configuration,
     bool init_only_config, bool mandatory, Types::Scalar type,
     std::vector<std::string> &&default_value) const {
-  throw std::invalid_argument(
-      "Yang case leaf-list not supported in base datamodel");
+  std::function<Response(const std::string &, const ListKeyValues &keys)>
+      read_handler_;
+  std::function<Response(const std::string &, const nlohmann::json &,
+                         const ListKeyValues &, Endpoint::Operation)>
+      replace_handler_;
+
+  // TODO: I need to capture this variable inside the lambda functions,
+  // capturing "this" for me is not working
+  auto local_core = this->core_;
+
+  auto tree_names_ = tree_names;
+  tree_names_.pop();
+
+  if (tree_names_.size() == 2) {
+    if (tree_names_.front() != "ports") {
+      throw std::runtime_error("unknown element found in base datamodel");
+    }
+
+    tree_names_.pop();
+    auto leaf = tree_names_.front();
+    if (leaf == "tcubes") {
+      read_handler_ = [local_core](const std::string &cube_name,
+                                   const ListKeyValues &keys) -> Response {
+        return local_core->base_model()->get_port_tcubes(cube_name,
+                                                         keys[0].value);
+      };
+    } else {
+      throw std::runtime_error("unknown element found in base datamodel: " +
+                               leaf);
+    }
+  }
+
+  return std::make_unique<LeafListResource>(
+    std::move(read_handler_), std::move(replace_handler_), name, description,
+    cli_example, rest_endpoint, parent, configuration, init_only_config,
+    core_, std::move(value_field), node_fields, mandatory, type, std::move(default_value));
 }
 
 std::unique_ptr<Endpoint::ListResource> ConcreteFactory::RestList(

--- a/src/polycubed/src/server/Resources/Data/BaseModel/LeafListResource.cpp
+++ b/src/polycubed/src/server/Resources/Data/BaseModel/LeafListResource.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 The Polycube Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "LeafListResource.h"
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "../../Body/JsonNodeField.h"
+
+namespace polycube::polycubed::Rest::Resources::Data::BaseModel {
+LeafListResource::LeafListResource(
+    std::function<Response(const std::string &, const ListKeyValues &keys)>
+        read_handler,
+    std::function<Response(const std::string &, const nlohmann::json &,
+                           const ListKeyValues &, Endpoint::Operation)>
+        replace_handler,
+    const std::string &name, const std::string &description,
+    const std::string &cli_example, const std::string &rest_endpoint,
+    const Body::ParentResource *parent, bool configuration,
+    bool init_only_config, PolycubedCore *core,
+    std::unique_ptr<Body::JsonValueField> &&value_field,
+    const std::vector<Body::JsonNodeField> &node_fields, bool mandatory,
+    Types::Scalar type, std::vector<std::string> &&default_value)
+    : Body::LeafListResource(name, description, cli_example, parent, core,
+                         std::move(value_field), node_fields, configuration,
+                         init_only_config, mandatory, type, std::move(default_value)),
+      Body::LeafResource(name, description, cli_example, parent, core,
+                         std::move(value_field), node_fields, configuration,
+                         init_only_config, mandatory, type, nullptr),
+      Endpoint::LeafListResource(name, description, cli_example, rest_endpoint,
+                             parent, core, nullptr, node_fields, configuration,
+                             init_only_config, mandatory, type, std::move(default_value)),
+      read_handler_{std::move(read_handler)},
+      replace_handler_{std::move(replace_handler)} {}
+
+const Response LeafListResource::ReadValue(const std::string &cube_name,
+                                       const ListKeyValues &keys) const {
+  return read_handler_(cube_name, keys);
+}
+
+Response LeafListResource::WriteValue(const std::string &cube_name,
+                                  const nlohmann::json &value,
+                                  const ListKeyValues &keys,
+                                  Endpoint::Operation operation) {
+  return replace_handler_(cube_name, value, keys, operation);
+}
+}  // namespace polycube::polycubed::Rest::Resources::Data::BaseModel

--- a/src/polycubed/src/server/Resources/Data/BaseModel/LeafListResource.h
+++ b/src/polycubed/src/server/Resources/Data/BaseModel/LeafListResource.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 The Polycube Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <stack>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "../../Endpoint/LeafListResource.h"
+#include "polycube/services/shared_lib_elements.h"
+
+namespace polycube::polycubed::Rest::Resources::Endpoint {
+class ParentResource;
+}
+
+namespace polycube::polycubed::Rest::Resources::Data::BaseModel {
+
+class LeafListResource : public Endpoint::LeafListResource {
+ public:
+  LeafListResource(
+      std::function<Response(const std::string &, const ListKeyValues &keys)>
+          read_handler,
+      std::function<Response(const std::string &, const nlohmann::json &,
+                             const ListKeyValues &, Endpoint::Operation)>
+          replace_handler,
+      const std::string &name, const std::string &description,
+      const std::string &cli_example, const std::string &rest_endpoint,
+      const Body::ParentResource *parent, bool configuration,
+      bool init_only_config, PolycubedCore *core,
+      std::unique_ptr<Body::JsonValueField> &&value_field,
+      const std::vector<Body::JsonNodeField> &node_fields, bool mandatory,
+      Types::Scalar type, std::vector<std::string> &&default_value);
+
+  const Response ReadValue(const std::string &cube_name,
+                           const ListKeyValues &keys) const final;
+
+  Response WriteValue(const std::string &cube_name, const nlohmann::json &value,
+                      const ListKeyValues &keys,
+                      Endpoint::Operation operation) final;
+
+ private:
+  std::function<Response(const std::string &, const ListKeyValues &keys)>
+      read_handler_;
+  std::function<Response(const std::string &, const nlohmann::json &,
+                         const ListKeyValues &, Endpoint::Operation)>
+      replace_handler_;
+};
+}  // namespace polycube::polycubed::Rest::Resources::Data::BaseModel

--- a/src/polycubed/src/server/Resources/Endpoint/LeafListResource.h
+++ b/src/polycubed/src/server/Resources/Endpoint/LeafListResource.h
@@ -27,7 +27,7 @@ namespace polycube::polycubed::Rest::Resources::Endpoint {
 using Pistache::Http::ResponseWriter;
 using Pistache::Rest::Request;
 
-class LeafListResource : public LeafResource, public Body::LeafListResource {
+class LeafListResource : public LeafResource, virtual public Body::LeafListResource {
  public:
   LeafListResource(const std::string &name, const std::string &description,
                    const std::string &cli_example,
@@ -41,11 +41,5 @@ class LeafListResource : public LeafResource, public Body::LeafListResource {
                    std::vector<std::string> &&default_value);
 
   ~LeafListResource() override;
-
-  virtual std::shared_ptr<LeafResource> &Entry(
-      const std::string &value) const = 0;
-
- private:
-  void get_entry(const Request &request, ResponseWriter response);
 };
 }  // namespace polycube::polycubed::Rest::Resources::Endpoint

--- a/src/polycubed/src/server/Resources/Endpoint/LeafResource.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/LeafResource.cpp
@@ -26,6 +26,8 @@
 #include "../../Server/ResponseGenerator.h"
 #include "Service.h"
 #include "rest_server.h"
+#include "../../config.h"
+#include "cubes_dump.h"
 
 namespace polycube::polycubed::Rest::Resources::Endpoint {
 LeafResource::LeafResource(
@@ -113,6 +115,12 @@ void LeafResource::CreateReplaceUpdate(const Pistache::Rest::Request &request,
     auto op = Operation::kUpdate;
     auto resp = WriteValue(cube_name, jbody, keys, op);
     errors.push_back(resp);
+    // check if the operation completed successfully and in case update the configuration
+    if (isOperationSuccessful(resp.error_tag)) {
+      if (auto d = core_->get_cubes_dump()) {
+        d->UpdateCubesConfig(request.resource(), jbody, keys, op, ResourceType::LeafResource);
+      }
+    }
   }
   Server::ResponseGenerator::Generate(std::move(errors), std::move(response));
 }

--- a/src/polycubed/src/server/Resources/Endpoint/ParentResource.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/ParentResource.cpp
@@ -26,6 +26,8 @@
 #include "../Body/JsonNodeField.h"
 #include "../Body/ListKey.h"
 #include "Service.h"
+#include "../../config.h"
+#include "cubes_dump.h"
 
 #include "LeafResource.h"
 #include "ListResource.h"
@@ -126,6 +128,12 @@ void ParentResource::CreateReplaceUpdate(
     } else {
       errors.push_back(resp);
     }
+    // check if the operation completed successfully and in case update the configuration
+    if (isOperationSuccessful(resp.error_tag)) {
+      if (auto d = core_->get_cubes_dump()) {
+        d->UpdateCubesConfig(request.resource(), jbody, keys, op, ResourceType::ParentResource);
+      }
+    }
   }
   Server::ResponseGenerator::Generate(std::move(errors), std::move(response));
 }
@@ -204,11 +212,15 @@ void ParentResource::del(const Request &request, ResponseWriter response) {
     return;
   }
   auto resp = DeleteValue(cube_name, keys);
+  // check if the operation completed successfully and in case update the configuration
   if (resp.error_tag == ErrorTag::kOk) {
     Server::ResponseGenerator::Generate(
         std::vector<Response>{{ErrorTag::kNoContent, nullptr}},
         std::move(response));
     errors.push_back({ErrorTag::kCreated, nullptr});
+    if (auto d = core_->get_cubes_dump()) {
+      d->UpdateCubesConfig(request.resource(), nullptr, keys, Operation::kDelete, ResourceType::ParentResource);
+    }
   } else {
     Server::ResponseGenerator::Generate(std::vector<Response>{resp},
                                         std::move(response));

--- a/src/polycubed/src/server/Resources/Endpoint/Resource.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/Resource.cpp
@@ -16,6 +16,9 @@
 #include "Resource.h"
 
 #include <string>
+#include <fstream>
+#include <rest_server.h>
+#include "../../config.h"
 
 namespace polycube::polycubed::Rest::Resources::Endpoint {
 
@@ -33,4 +36,11 @@ Operation Resource::OperationType(bool update, bool initialization) {
     }
   }
 }
+
+bool Resource::isOperationSuccessful(ErrorTag errorTag) {
+  return errorTag == ErrorTag::kOk ||
+         errorTag == ErrorTag::kCreated ||
+         errorTag == ErrorTag::kNoContent;
+}
+
 }  // namespace polycube::polycubed::Rest::Resources::Endpoint

--- a/src/polycubed/src/server/Resources/Endpoint/Resource.h
+++ b/src/polycubed/src/server/Resources/Endpoint/Resource.h
@@ -26,10 +26,12 @@
 
 namespace polycube::polycubed::Rest::Resources::Endpoint {
 
-enum class Operation { kCreate, kReplace, kUpdate };
+enum class Operation { kCreate, kReplace, kUpdate, kDelete };
+enum class ResourceType {Service, ParentResource, ListResource, LeafResource};
 
 class Resource {
  public:
+
   explicit Resource(const std::string &rest_endpoint);
 
   virtual ~Resource() = default;
@@ -55,6 +57,8 @@ class Resource {
                                    bool update, bool initialization) = 0;
 
   static Operation OperationType(bool update, bool initialization);
+
+  static bool isOperationSuccessful(ErrorTag errorTag);
 
   virtual void Keys(const Pistache::Rest::Request &request,
                     ListKeyValues &parsed) const = 0;

--- a/src/polycubed/src/server/Resources/Endpoint/Service.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/Service.cpp
@@ -18,6 +18,8 @@
 #include "polycube/services/cube_factory.h"
 #include "polycubed_core.h"
 #include "rest_server.h"
+#include "../../config.h"
+#include "cubes_dump.h"
 
 #include "../../Server/ResponseGenerator.h"
 #include "../Body/JsonNodeField.h"
@@ -97,10 +99,14 @@ Service::CreateReplaceUpdate(const std::string &name, nlohmann::json &body, bool
    auto cubes_list = utils::strip_port_tcubes(body);
 
     auto resp = WriteValue(name, body, k, op);
-    if (!update && (resp.error_tag == ErrorTag::kOk ||
-                    resp.error_tag == ErrorTag::kCreated ||
-                    resp.error_tag == ErrorTag::kNoContent)) {
-      cube_names_.AddValue(name);
+    // check if the operation completed successfully and in case update the configuration
+    if (isOperationSuccessful(resp.error_tag)) {
+      if (!update) {
+        cube_names_.AddValue(name);
+      }
+      if (auto d = core_->get_cubes_dump()) {
+        d->UpdateCubesConfig(RestServer::base + this->name_ + "/" + name + "/", body, k, op, ResourceType::Service);
+      }
     }
 
     // use  previously calculated list to update ports' transparent cubes
@@ -209,6 +215,9 @@ void Service::del(const Pistache::Rest::Request &request,
   auto res = DeleteValue(name, k);
   Server::ResponseGenerator::Generate(std::vector<Response>{res},
                                       std::move(response));
+  if (auto d = core_->get_cubes_dump()) {
+    d->UpdateCubesConfig(RestServer::base + this->name_ + "/" + name + "/", nullptr, k, Operation::kDelete, ResourceType::Service);
+  }
 }
 
 void Service::patch_body(const Request &request, ResponseWriter response) {

--- a/src/polycubed/src/utils/utils.cpp
+++ b/src/polycubed/src/utils/utils.cpp
@@ -67,6 +67,31 @@ std::map<std::string, std::string> strip_port_peers(json &cubes) {
   return peers;
 }
 
+std::map<std::string, json> strip_port_tcubes(json &jcube) {
+  std::map<std::string, json> cubes;
+
+  if (!jcube.count("ports")) {
+    return cubes;
+  }
+
+  auto &jports = jcube.at("ports");
+
+  for (auto &jport : jports) {
+    if (!jport.count("tcubes")) {
+      continue;
+    }
+
+    auto port_name = jport.at("name").get<std::string>();
+
+    json jcubes = json::object();
+    jcubes["tcubes"] = jport.at("tcubes");
+    cubes[port_name] = jcubes;
+    jport.erase("tcubes");
+  }
+
+  return cubes;
+}
+
 }  // namespace utils
 }  // namespace polycubed
 }  // namespace polycube

--- a/src/polycubed/src/utils/utils.cpp
+++ b/src/polycubed/src/utils/utils.cpp
@@ -44,6 +44,29 @@ bool check_kernel_version(const std::string &version) {
          KERNEL_VERSION(major_r, minor_r, patch_r);
 }
 
+std::map<std::string, std::string> strip_port_peers(json &cubes) {
+  std::map<std::string, std::string> peers;
+
+  for (auto &cube : cubes) {
+    if (!cube.count("ports")) {
+      continue;
+    }
+
+    auto &ports = cube.at("ports");
+
+    for (auto &port : ports) {
+      if (port.count("peer")) {
+        auto cube_name = cube.at("name").get<std::string>();
+        auto port_name = port.at("name").get<std::string>();
+        peers[cube_name + ":" + port_name] = port.at("peer").get<std::string>();
+        port.erase("peer");
+      }
+    }
+  }
+
+  return peers;
+}
+
 }  // namespace utils
 }  // namespace polycubed
 }  // namespace polycube

--- a/src/polycubed/src/utils/utils.h
+++ b/src/polycubed/src/utils/utils.h
@@ -26,6 +26,7 @@ namespace utils {
 
 bool check_kernel_version(const std::string &version);
 std::map<std::string, std::string> strip_port_peers(json &cubes);
+std::map<std::string, json> strip_port_tcubes(json &jcube);
 
 }  // namespace utils
 }  // namespace polycubed

--- a/src/polycubed/src/utils/utils.h
+++ b/src/polycubed/src/utils/utils.h
@@ -15,12 +15,17 @@
  */
 
 #include <string>
+#include <map>
+#include "polycube/services/json.hpp"
+
+using json = nlohmann::json;
 
 namespace polycube {
 namespace polycubed {
 namespace utils {
 
 bool check_kernel_version(const std::string &version);
+std::map<std::string, std::string> strip_port_peers(json &cubes);
 
 }  // namespace utils
 }  // namespace polycubed

--- a/src/services/datamodel-common/polycube-standard-base.yang
+++ b/src/services/datamodel-common/polycube-standard-base.yang
@@ -40,6 +40,12 @@ module polycube-standard-base {
         description "Peer name, such as a network interfaces (e.g., 'veth0') or another cube (e.g., 'br1:port2')";
         polycube-base:cli-example "r0:port1";
       }
+
+      leaf-list tcubes {
+        polycube-base:init-only-config;
+        description "List of transparent cubes attached to this port";
+        type string;
+      }
     }
 
     leaf shadow {

--- a/src/services/pcn-nat/src/Nat.cpp
+++ b/src/services/pcn-nat/src/Nat.cpp
@@ -83,6 +83,12 @@ void Nat::attach() {
     auto temp = get_parent_parameter("ip");
     external_ip_ = temp.substr(1, temp.length() - 2);  // remove qoutes
     logger()->info("external ip is : {}", external_ip_);
+    // if masquerare is enabled we need to update the IP address
+    // TODO: this action should also be performed when the IP address on the
+    // parent changes (it needs the subscription mechanishm)
+    if (rule_->getMasquerade()->getEnabled()) {
+      rule_->getMasquerade()->inject(utils::ip_string_to_be_uint(external_ip_));
+    }
   } catch (...) {
     logger()->warn("External IP not found. Is this enabled on a router?");
   }

--- a/src/services/pcn-nat/src/Rule.cpp
+++ b/src/services/pcn-nat/src/Rule.cpp
@@ -20,11 +20,11 @@
 #include "Nat.h"
 
 Rule::Rule(Nat &parent, const RuleJsonObject &conf) : parent_(parent) {
-  update(conf);
   snat_ = std::make_shared<RuleSnat>(*this);
   dnat_ = std::make_shared<RuleDnat>(*this);
   portforwarding_ = std::make_shared<RulePortForwarding>(*this);
   masquerade_ = std::make_shared<RuleMasquerade>(*this);
+  update(conf);
 }
 
 Rule::~Rule() {

--- a/src/services/pcn-nat/src/RuleMasquerade.h
+++ b/src/services/pcn-nat/src/RuleMasquerade.h
@@ -25,6 +25,7 @@ class Rule;
 using namespace io::swagger::server::model;
 
 class RuleMasquerade : public RuleMasqueradeInterface {
+  friend class Nat;
  public:
   RuleMasquerade(Rule &parent);
   RuleMasquerade(Rule &parent, const RuleMasqueradeJsonObject &conf);
@@ -41,6 +42,7 @@ class RuleMasquerade : public RuleMasqueradeInterface {
   void setEnabled(const bool &value) override;
 
  private:
+  bool inject(uint32_t ip); // injects the rule in datapath
   Rule &parent_;
   bool enabled;
 };

--- a/src/services/pcn-router/src/Router.cpp
+++ b/src/services/pcn-router/src/Router.cpp
@@ -35,10 +35,9 @@ Router::Router(const std::string name, const RouterJsonObject &conf)
   logger()->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [Router] [%n] [%l] %v");
   logger()->info("Creating Router instance");
 
+  addPortsList(conf.getPorts());
   addArpEntryList(conf.getArpEntry());
   addRouteList(conf.getRoute());
-
-  addPortsList(conf.getPorts());
 
   if (get_shadow()) {
     // netlink notification

--- a/src/services/pcn-simplebridge/src/Simplebridge.cpp
+++ b/src/services/pcn-simplebridge/src/Simplebridge.cpp
@@ -30,8 +30,8 @@ Simplebridge::Simplebridge(const std::string name,
     : Cube(conf.getBase(), {simplebridge_code}, {}), quit_thread_(false),
       SimplebridgeBase(name) {
   logger()->info("Creating Simplebridge instance");
-  addFdb(conf.getFdb());
   addPortsList(conf.getPorts());
+  addFdb(conf.getFdb());
 
   timestamp_update_thread_ =
       std::thread(&Simplebridge::updateTimestampTimer, this);


### PR DESCRIPTION
This feature allows to load a topology from file at startup, either from the default folder or from a user selected file (ex. `polycubed --cubes-dump ~/Desktop/cubes.yaml`), keeping the whole configuration in memory.
After each modification in any of the topology of the cube, the configuration in memory is updated and another thread saves it to file updating it too.
It is possible to start the daemon with an empty topology by using the flag `--cubes-init`: if the file contains a topology, at the first update it is overwritten.
It is possible to start the daemon without the dumping to file functionality by using the flag `--cubes-nodump`.