### PR TITLE
polycubed: fix packet out deadlock when attaching transparent cubes

### DIFF
--- a/src/polycubed/src/port.cpp
+++ b/src/polycubed/src/port.cpp
@@ -49,11 +49,10 @@ uint16_t Port::index() const {
 }
 
 uint16_t Port::get_index() const {
-  std::lock_guard<std::mutex> guard(port_mutex_);
-  return __get_index();
+  return port_index_;
 }
 
-uint16_t Port::__get_index() const {
+uint16_t Port::calculate_index() const {
   // check if there is ingress-enabled transparent cube
   for (auto it = cubes_.rbegin(); it != cubes_.rend(); ++it) {
     auto index = (*it)->get_index(ProgramType::INGRESS);
@@ -230,9 +229,11 @@ void Port::update_indexes() {
     }
   }
 
+  port_index_ = calculate_index();
+
   // CASE4: peer -> cube[N-1]
   if (peer_port_) {
-    peer_port_->set_next_index(__get_index());
+    peer_port_->set_next_index(port_index_);
   }
 
   // egress chain: port -> cubes[0] -> ... -> cube[N -1] -> peer

--- a/src/polycubed/src/port.h
+++ b/src/polycubed/src/port.h
@@ -100,7 +100,8 @@ class Port : public polycube::service::PortIface, public PeerIface {
   std::shared_ptr<spdlog::logger> logger;
 
  private:
-  uint16_t __get_index() const;
+  uint16_t port_index_; // ebpf id used by other modules to call this port
+  uint16_t calculate_index() const;
 };
 
 }  // namespace polycubed


### PR DESCRIPTION
    A dead lock is possible when a transparent cube is added to a port
    and there is a packetout operation at the same time.
    If port1 and port2 are connected, a packetout operation is going
    on port1 and a cube is attached to port2
    
```
    Thread1:                          | Thread2:
    port1->send_packet_out()          | port2->add_cube()
      lock(port1)                     |   lock(port2)
      ...                             |   ...
      port2->get_index()              |   port1->set_next_index()
        lock(port2)                   |     lock(port1)
  ```  
    The main cause of this is that send_packet_out() uses get_index() that
    internally uses a lock.  This commit modifies get_index() so it doesn't