### PR TITLE
Fix issues when loading full topology with a single command

### DIFF
--- a/src/libs/polycube/include/polycube/services/cube.h
+++ b/src/libs/polycube/include/polycube/services/cube.h
@@ -115,6 +115,19 @@ std::shared_ptr<PortType> Cube<PortType>::add_port(const std::string &port_name,
 
     std::tie(iter, inserted) = ports_by_name_.emplace(port_name, port);
     ports_by_id_.emplace(port->index(), port);
+    /*
+     * When a transparent cube is attached to a port, it can query the service
+     * to get some port parameters (e.g., MAC address). If the transparent cube
+     * is attached while the port is being created these parameters will be not
+     * configured yet.
+     * This workaround first creates the port and then passes the configuration
+     * to attach the transparent cubes. The configuration that is passed
+     * in the constructor is ignored in the daemon.
+     * The solution for this workaround would be to implement the notification
+     * mechanishm, so when the parameters are configured those are pushed to the
+     * transparent cube.
+     */
+    port->set_conf(conf.getBase());
     return iter->second;
   } catch (const std::exception &ex) {
     cube_->remove_port(port_name);

--- a/src/polycubed/src/base_model.cpp
+++ b/src/polycubed/src/base_model.cpp
@@ -179,4 +179,24 @@ Response BaseModel::set_port_peer(const std::string &cube_name,
   return Response{kOk, ::strdup("")};
 }
 
+Response BaseModel::get_port_tcubes(const std::string &cube_name,
+                                    const std::string &port_name) const {
+  auto cube_ = ServiceController::get_cube(cube_name);
+  if (cube_ == nullptr) {
+    return Response{kNoContent, ::strdup("Cube does not exist")};
+  }
+
+  // TODO: is this case even possible?
+  auto cube = std::dynamic_pointer_cast<CubeIface>(cube_);
+  if (cube == nullptr) {
+    return Response{kNoContent, ::strdup("Cube is transparent")};
+  }
+
+  auto port_ = cube->get_port(port_name);
+  auto port = std::dynamic_pointer_cast<Port>(port_);
+  nlohmann::json j = port->get_cubes_names();
+
+  return Response{kOk, ::strdup(j.dump().c_str())};
+}
+
 }  // namespace polycube::polycubed

--- a/src/polycubed/src/base_model.h
+++ b/src/polycubed/src/base_model.h
@@ -46,6 +46,8 @@ class BaseModel {
   Response set_port_peer(const std::string &cube_name,
                          const std::string &port_name,
                          const nlohmann::json &json);
+  Response get_port_tcubes(const std::string &cube_name,
+                           const std::string &port_name) const;
 };
 
 }  // namespace polycube::polycubed

--- a/src/polycubed/src/peer_iface.cpp
+++ b/src/polycubed/src/peer_iface.cpp
@@ -111,6 +111,18 @@ void PeerIface::remove_cube(const std::string &cube_name) {
   update_indexes();
 }
 
+std::vector<std::string> PeerIface::get_cubes_names() const {
+  std::lock_guard<std::mutex> guard(mutex_);
+
+  std::vector<std::string> cubes_names;
+
+  for (auto &cube : cubes_) {
+    cubes_names.push_back(cube->get_name());
+  }
+
+  return cubes_names;
+}
+
 PeerIface::CubePositionComparison PeerIface::compare_position(
     const std::string &cube1, const std::string &cube2) {
   // cube position, index 0 is the innermost one

--- a/src/polycubed/src/peer_iface.h
+++ b/src/polycubed/src/peer_iface.h
@@ -43,6 +43,7 @@ class PeerIface {
   void add_cube(TransparentCube *cube, const std::string &position,
                 const std::string &other);
   void remove_cube(const std::string &type);
+  std::vector<std::string> get_cubes_names() const;
 
  protected:
   enum class CubePositionComparison {

--- a/src/polycubed/src/polycubed_core.cpp
+++ b/src/polycubed/src/polycubed_core.cpp
@@ -378,8 +378,8 @@ void PolycubedCore::attach(const std::string &cube_name,
         ServiceController::ports_to_ifaces.at(port_name));
   }
 
-  cube->set_parent(peer.get());
   peer->add_cube(cube.get(), position, other);
+  cube->set_parent(peer.get());
 }
 
 void PolycubedCore::detach(const std::string &cube_name,

--- a/src/polycubed/src/polycubed_core.cpp
+++ b/src/polycubed/src/polycubed_core.cpp
@@ -343,7 +343,7 @@ void PolycubedCore::attach(const std::string &cube_name,
       }
       break;
     case PortType::XDP:
-      if (cube->get_type() != CubeType::XDP_DRV &&
+      if (cube->get_type() != CubeType::XDP_SKB &&
           cube->get_type() != CubeType::XDP_DRV) {
         throw std::runtime_error(cube_name + " and " + port_name +
                                  " have incompatible types");

--- a/src/polycubed/src/polycubed_core.h
+++ b/src/polycubed/src/polycubed_core.h
@@ -39,6 +39,7 @@ namespace polycubed {
 class RestServer;
 
 class PolycubedCore {
+  friend class RestServer;
  public:
   PolycubedCore(BaseModel *base_model);
   ~PolycubedCore();

--- a/src/polycubed/src/port.cpp
+++ b/src/polycubed/src/port.cpp
@@ -161,6 +161,13 @@ void Port::set_conf(const nlohmann::json &conf) {
   if (conf.count("peer")) {
     set_peer(conf.at("peer").get<std::string>());
   }
+
+  // attach transparent cubes present on the port
+  if (conf.count("tcubes")) {
+    for (auto &cube : conf.at("tcubes")) {
+      core->attach(cube.get<std::string>(), get_path(), "last", "");
+    }
+  }
 }
 
 nlohmann::json Port::to_json() const {
@@ -170,6 +177,11 @@ nlohmann::json Port::to_json() const {
   val["uuid"] = uuid().str();
   val["status"] = port_status_to_string(get_status());
   val["peer"] = peer();
+
+  const auto &cubes_names = get_cubes_names();
+  if (cubes_names.size()) {
+    val["tcubes"] = cubes_names;
+  }
 
   return val;
 }

--- a/src/polycubed/src/server/Parser/YangNodes.tcpp
+++ b/src/polycubed/src/server/Parser/YangNodes.tcpp
@@ -395,10 +395,13 @@ void Yang::ParseLeafList(
   }
   std::shared_ptr<Resources::Body::LeafListResource> resource;
   if (generate_endpoint) {
+    auto base_model = base_model_factory_->IsBaseModel(parsed_names);
+    auto &&factory__ = base_model ? dynamic_cast<Resources::Data::AbstractFactory*>(base_model_factory_.get()) : factory_.get();
+
     const auto &e_parent =
         std::dynamic_pointer_cast<Resources::Endpoint::ParentResource>(parent);
     auto endpoint = e_parent->Endpoint() + '/' + leaflist->name;
-    resource = factory_->RestLeafList(
+    resource = factory__->RestLeafList(
         std::move(parsed_names), leaflist->name, description, cli_example,
         endpoint, parent.get(), std::move(value_field), node_fields,
         configuration, init_only_config, mandatory,

--- a/src/polycubed/src/server/Resources/Data/BaseModel/CMakeLists.txt
+++ b/src/polycubed/src/server/Resources/Data/BaseModel/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(base_model_sources
         ${CMAKE_CURRENT_LIST_DIR}/ConcreteFactory.cpp
         ${CMAKE_CURRENT_LIST_DIR}/LeafResource.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/LeafListResource.cpp
         PARENT_SCOPE)

--- a/src/polycubed/src/server/Resources/Data/BaseModel/LeafListResource.cpp
+++ b/src/polycubed/src/server/Resources/Data/BaseModel/LeafListResource.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 The Polycube Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "LeafListResource.h"
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "../../Body/JsonNodeField.h"
+
+namespace polycube::polycubed::Rest::Resources::Data::BaseModel {
+LeafListResource::LeafListResource(
+    std::function<Response(const std::string &, const ListKeyValues &keys)>
+        read_handler,
+    std::function<Response(const std::string &, const nlohmann::json &,
+                           const ListKeyValues &, Endpoint::Operation)>
+        replace_handler,
+    const std::string &name, const std::string &description,
+    const std::string &cli_example, const std::string &rest_endpoint,
+    const Body::ParentResource *parent, bool configuration,
+    bool init_only_config, PolycubedCore *core,
+    std::unique_ptr<Body::JsonValueField> &&value_field,
+    const std::vector<Body::JsonNodeField> &node_fields, bool mandatory,
+    Types::Scalar type, std::vector<std::string> &&default_value)
+    : Body::LeafListResource(name, description, cli_example, parent, core,
+                         std::move(value_field), node_fields, configuration,
+                         init_only_config, mandatory, type, std::move(default_value)),
+      Body::LeafResource(name, description, cli_example, parent, core,
+                         std::move(value_field), node_fields, configuration,
+                         init_only_config, mandatory, type, nullptr),
+      Endpoint::LeafListResource(name, description, cli_example, rest_endpoint,
+                             parent, core, nullptr, node_fields, configuration,
+                             init_only_config, mandatory, type, std::move(default_value)),
+      read_handler_{std::move(read_handler)},
+      replace_handler_{std::move(replace_handler)} {}
+
+const Response LeafListResource::ReadValue(const std::string &cube_name,
+                                       const ListKeyValues &keys) const {
+  return read_handler_(cube_name, keys);
+}
+
+Response LeafListResource::WriteValue(const std::string &cube_name,
+                                  const nlohmann::json &value,
+                                  const ListKeyValues &keys,
+                                  Endpoint::Operation operation) {
+  return replace_handler_(cube_name, value, keys, operation);
+}
+}  // namespace polycube::polycubed::Rest::Resources::Data::BaseModel

--- a/src/polycubed/src/server/Resources/Data/BaseModel/LeafListResource.h
+++ b/src/polycubed/src/server/Resources/Data/BaseModel/LeafListResource.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 The Polycube Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <stack>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "../../Endpoint/LeafListResource.h"
+#include "polycube/services/shared_lib_elements.h"
+
+namespace polycube::polycubed::Rest::Resources::Endpoint {
+class ParentResource;
+}
+
+namespace polycube::polycubed::Rest::Resources::Data::BaseModel {
+
+class LeafListResource : public Endpoint::LeafListResource {
+ public:
+  LeafListResource(
+      std::function<Response(const std::string &, const ListKeyValues &keys)>
+          read_handler,
+      std::function<Response(const std::string &, const nlohmann::json &,
+                             const ListKeyValues &, Endpoint::Operation)>
+          replace_handler,
+      const std::string &name, const std::string &description,
+      const std::string &cli_example, const std::string &rest_endpoint,
+      const Body::ParentResource *parent, bool configuration,
+      bool init_only_config, PolycubedCore *core,
+      std::unique_ptr<Body::JsonValueField> &&value_field,
+      const std::vector<Body::JsonNodeField> &node_fields, bool mandatory,
+      Types::Scalar type, std::vector<std::string> &&default_value);
+
+  const Response ReadValue(const std::string &cube_name,
+                           const ListKeyValues &keys) const final;
+
+  Response WriteValue(const std::string &cube_name, const nlohmann::json &value,
+                      const ListKeyValues &keys,
+                      Endpoint::Operation operation) final;
+
+ private:
+  std::function<Response(const std::string &, const ListKeyValues &keys)>
+      read_handler_;
+  std::function<Response(const std::string &, const nlohmann::json &,
+                         const ListKeyValues &, Endpoint::Operation)>
+      replace_handler_;
+};
+}  // namespace polycube::polycubed::Rest::Resources::Data::BaseModel

--- a/src/polycubed/src/server/Resources/Endpoint/LeafListResource.h
+++ b/src/polycubed/src/server/Resources/Endpoint/LeafListResource.h
@@ -27,7 +27,7 @@ namespace polycube::polycubed::Rest::Resources::Endpoint {
 using Pistache::Http::ResponseWriter;
 using Pistache::Rest::Request;
 
-class LeafListResource : public LeafResource, public Body::LeafListResource {
+class LeafListResource : public LeafResource, virtual public Body::LeafListResource {
  public:
   LeafListResource(const std::string &name, const std::string &description,
                    const std::string &cli_example,
@@ -41,11 +41,5 @@ class LeafListResource : public LeafResource, public Body::LeafListResource {
                    std::vector<std::string> &&default_value);
 
   ~LeafListResource() override;
-
-  virtual std::shared_ptr<LeafResource> &Entry(
-      const std::string &value) const = 0;
-
- private:
-  void get_entry(const Request &request, ResponseWriter response);
 };
 }  // namespace polycube::polycubed::Rest::Resources::Endpoint

--- a/src/polycubed/src/utils/utils.cpp
+++ b/src/polycubed/src/utils/utils.cpp
@@ -67,6 +67,31 @@ std::map<std::string, std::string> strip_port_peers(json &cubes) {
   return peers;
 }
 
+std::map<std::string, json> strip_port_tcubes(json &jcube) {
+  std::map<std::string, json> cubes;
+
+  if (!jcube.count("ports")) {
+    return cubes;
+  }
+
+  auto &jports = jcube.at("ports");
+
+  for (auto &jport : jports) {
+    if (!jport.count("tcubes")) {
+      continue;
+    }
+
+    auto port_name = jport.at("name").get<std::string>();
+
+    json jcubes = json::object();
+    jcubes["tcubes"] = jport.at("tcubes");
+    cubes[port_name] = jcubes;
+    jport.erase("tcubes");
+  }
+
+  return cubes;
+}
+
 }  // namespace utils
 }  // namespace polycubed
 }  // namespace polycube

--- a/src/polycubed/src/utils/utils.cpp
+++ b/src/polycubed/src/utils/utils.cpp
@@ -44,6 +44,29 @@ bool check_kernel_version(const std::string &version) {
          KERNEL_VERSION(major_r, minor_r, patch_r);
 }
 
+std::map<std::string, std::string> strip_port_peers(json &cubes) {
+  std::map<std::string, std::string> peers;
+
+  for (auto &cube : cubes) {
+    if (!cube.count("ports")) {
+      continue;
+    }
+
+    auto &ports = cube.at("ports");
+
+    for (auto &port : ports) {
+      if (port.count("peer")) {
+        auto cube_name = cube.at("name").get<std::string>();
+        auto port_name = port.at("name").get<std::string>();
+        peers[cube_name + ":" + port_name] = port.at("peer").get<std::string>();
+        port.erase("peer");
+      }
+    }
+  }
+
+  return peers;
+}
+
 }  // namespace utils
 }  // namespace polycubed
 }  // namespace polycube

--- a/src/polycubed/src/utils/utils.h
+++ b/src/polycubed/src/utils/utils.h
@@ -26,6 +26,7 @@ namespace utils {
 
 bool check_kernel_version(const std::string &version);
 std::map<std::string, std::string> strip_port_peers(json &cubes);
+std::map<std::string, json> strip_port_tcubes(json &jcube);
 
 }  // namespace utils
 }  // namespace polycubed

--- a/src/polycubed/src/utils/utils.h
+++ b/src/polycubed/src/utils/utils.h
@@ -15,12 +15,17 @@
  */
 
 #include <string>
+#include <map>
+#include "polycube/services/json.hpp"
+
+using json = nlohmann::json;
 
 namespace polycube {
 namespace polycubed {
 namespace utils {
 
 bool check_kernel_version(const std::string &version);
+std::map<std::string, std::string> strip_port_peers(json &cubes);
 
 }  // namespace utils
 }  // namespace polycubed

--- a/src/services/datamodel-common/polycube-standard-base.yang
+++ b/src/services/datamodel-common/polycube-standard-base.yang
@@ -40,6 +40,12 @@ module polycube-standard-base {
         description "Peer name, such as a network interfaces (e.g., 'veth0') or another cube (e.g., 'br1:port2')";
         polycube-base:cli-example "r0:port1";
       }
+
+      leaf-list tcubes {
+        polycube-base:init-only-config;
+        description "List of transparent cubes attached to this port";
+        type string;
+      }
     }
   }
 }

--- a/src/services/pcn-nat/src/Nat.cpp
+++ b/src/services/pcn-nat/src/Nat.cpp
@@ -83,6 +83,12 @@ void Nat::attach() {
     auto temp = get_parent_parameter("ip");
     external_ip_ = temp.substr(1, temp.length() - 2);  // remove qoutes
     logger()->info("external ip is : {}", external_ip_);
+    // if masquerare is enabled we need to update the IP address
+    // TODO: this action should also be performed when the IP address on the
+    // parent changes (it needs the subscription mechanishm)
+    if (rule_->getMasquerade()->getEnabled()) {
+      rule_->getMasquerade()->inject(utils::ip_string_to_be_uint(external_ip_));
+    }
   } catch (...) {
     logger()->warn("External IP not found. Is this enabled on a router?");
   }

--- a/src/services/pcn-nat/src/Rule.cpp
+++ b/src/services/pcn-nat/src/Rule.cpp
@@ -20,11 +20,11 @@
 #include "Nat.h"
 
 Rule::Rule(Nat &parent, const RuleJsonObject &conf) : parent_(parent) {
-  update(conf);
   snat_ = std::make_shared<RuleSnat>(*this);
   dnat_ = std::make_shared<RuleDnat>(*this);
   portforwarding_ = std::make_shared<RulePortForwarding>(*this);
   masquerade_ = std::make_shared<RuleMasquerade>(*this);
+  update(conf);
 }
 
 Rule::~Rule() {

--- a/src/services/pcn-nat/src/RuleMasquerade.h
+++ b/src/services/pcn-nat/src/RuleMasquerade.h
@@ -25,6 +25,7 @@ class Rule;
 using namespace io::swagger::server::model;
 
 class RuleMasquerade : public RuleMasqueradeInterface {
+  friend class Nat;
  public:
   RuleMasquerade(Rule &parent);
   RuleMasquerade(Rule &parent, const RuleMasqueradeJsonObject &conf);
@@ -41,6 +42,7 @@ class RuleMasquerade : public RuleMasqueradeInterface {
   void setEnabled(const bool &value) override;
 
  private:
+  bool inject(uint32_t ip); // injects the rule in datapath
   Rule &parent_;
   bool enabled;
 };

--- a/src/services/pcn-router/src/Router.cpp
+++ b/src/services/pcn-router/src/Router.cpp
@@ -35,9 +35,8 @@ Router::Router(const std::string name, const RouterJsonObject &conf)
   logger()->info("Creating Router instance");
 
   addArpEntryList(conf.getArpEntry());
-  addRouteList(conf.getRoute());
-
   addPortsList(conf.getPorts());
+  addRouteList(conf.getRoute());
 }
 
 Router::~Router() {}

--- a/src/services/pcn-simplebridge/src/Simplebridge.cpp
+++ b/src/services/pcn-simplebridge/src/Simplebridge.cpp
@@ -30,8 +30,8 @@ Simplebridge::Simplebridge(const std::string name,
     : Cube(conf.getBase(), {simplebridge_code}, {}), quit_thread_(false),
       SimplebridgeBase(name) {
   logger()->info("Creating Simplebridge instance");
-  addFdb(conf.getFdb());
   addPortsList(conf.getPorts());
+  addFdb(conf.getFdb());
 
   timestamp_update_thread_ =
       std::thread(&Simplebridge::updateTimestampTimer, this);


### PR DESCRIPTION
https://github.com/polycube-network/polycube/pull/126 introduced the possibility of loading a list of cubes present in a yaml or json file. Although that PR worked in the simple cases, it was not possible to load complex topologies.  This PR addresses many of the problems present when creating a full topology from the configuration file:

- set the ports' peer after all the cubes have been created
- add a list of transparent cubes as property in ports, so on creation time this is possible to provide the list of cubes that should be attached to a given port
- fix a bug on the router that created the routing table before the ports
- extend the nat so it is able to reconfigure the masquerade rules when this is attached to a port

This PR is also useful for https://github.com/polycube-network/polycube/pull/141 as all the bugs present solved here affects that PR.