### PR TITLE
 Alignment between port/transparent_cube and netdev (when they are connected)

### DIFF
--- a/src/libs/polycube/include/polycube/services/cube_iface.h
+++ b/src/libs/polycube/include/polycube/services/cube_iface.h
@@ -20,6 +20,7 @@
 #include "polycube/services/guid.h"
 #include "polycube/services/port_iface.h"
 #include "polycube/services/table.h"
+#include "polycube/services/types.h"
 
 #include <map>
 #include <string>
@@ -95,7 +96,6 @@ class CubeIface : virtual public BaseCubeIface {
 class TransparentCubeIface : virtual public BaseCubeIface {
  public:
   virtual void set_next(uint16_t next, ProgramType type) = 0;
-  virtual std::string get_parent_parameter(const std::string &parameter) = 0;
   virtual void set_parameter(const std::string &parameter,
                              const std::string &value) = 0;
   virtual void send_packet_out(const std::vector<uint8_t> &packet, Sense sense,
@@ -103,6 +103,11 @@ class TransparentCubeIface : virtual public BaseCubeIface {
 
   virtual void set_conf(const nlohmann::json &conf) = 0;
   virtual nlohmann::json to_json() const = 0;
+
+  virtual void subscribe_parent_parameter(const std::string &param_name,
+                                        ParameterEventCallback &callback) = 0;
+  virtual void unsubscribe_parent_parameter(const std::string &param_name) = 0;
+  virtual std::string get_parent_parameter(const std::string &parameter) = 0;
 };
 }
 }

--- a/src/libs/polycube/include/polycube/services/port.h
+++ b/src/libs/polycube/include/polycube/services/port.h
@@ -56,6 +56,12 @@ class Port {
   // this uses a different naming convention
   std::string getName() const;
 
+  void subscribe_peer_parameter(const std::string &param_name,
+                                ParameterEventCallback &callback);
+  void unsubscribe_peer_parameter(const std::string &param_name);
+  void set_peer_parameter(const std::string &param_name,
+                          const std::string &value);
+
  private:
   class impl;
   std::unique_ptr<impl> pimpl_;

--- a/src/libs/polycube/include/polycube/services/port_iface.h
+++ b/src/libs/polycube/include/polycube/services/port_iface.h
@@ -23,6 +23,7 @@
 
 #include "polycube/services/cube_iface.h"
 #include "polycube/services/guid.h"
+#include "polycube/services/types.h"
 
 namespace polycube {
 namespace service {
@@ -55,6 +56,12 @@ class PortIface {
 
   virtual void set_conf(const nlohmann::json &conf) = 0;
   virtual nlohmann::json to_json() const = 0;
+
+  virtual void subscribe_peer_parameter(const std::string &param_name,
+                                        ParameterEventCallback &callback) = 0;
+  virtual void unsubscribe_peer_parameter(const std::string &param_name) = 0;
+  virtual void set_peer_parameter(const std::string &param_name,
+                                  const std::string &value) = 0;
 };
 }
 }

--- a/src/libs/polycube/include/polycube/services/transparent_cube.h
+++ b/src/libs/polycube/include/polycube/services/transparent_cube.h
@@ -49,8 +49,6 @@ class TransparentCube : public BaseCube {
   virtual void packet_in(Sense sense, PacketInMetadata &md,
                          const std::vector<uint8_t> &packet) = 0;
 
-  std::string get_parent_parameter(const std::string &parameter);
-
   void send_packet_out(EthernetII &packet, Sense sense,
                        bool recirculate = false);
 
@@ -58,6 +56,11 @@ class TransparentCube : public BaseCube {
   nlohmann::json to_json() const;
 
   virtual void attach();
+
+  void subscribe_parent_parameter(const std::string &param_name,
+                                  ParameterEventCallback &callback);
+  void unsubscribe_parent_parameter(const std::string &param_name);
+  std::string get_parent_parameter(const std::string &param_name);
 
  private:
   std::shared_ptr<TransparentCubeIface>

--- a/src/libs/polycube/include/polycube/services/types.h
+++ b/src/libs/polycube/include/polycube/services/types.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 The Polycube Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+
+namespace polycube {
+namespace service {
+
+typedef std::function<void(const std::string, const std::string)>
+    ParameterEventCallback;
+
+}  // namespace service
+}  // namespace polycube

--- a/src/libs/polycube/src/port.cpp
+++ b/src/libs/polycube/src/port.cpp
@@ -44,6 +44,12 @@ class Port::impl {
   void set_conf(const nlohmann::json &conf);
   nlohmann::json to_json() const;
 
+  void subscribe_peer_parameter(const std::string &param_name,
+                                ParameterEventCallback &callback);
+  void unsubscribe_peer_parameter(const std::string &param_name);
+  void set_peer_parameter(const std::string &param_name,
+                          const std::string &value);
+
  private:
   std::shared_ptr<PortIface> port_;  // port in polycubed
   // FIXME: Two different constructor needed. Look at BridgePort example
@@ -109,6 +115,20 @@ void Port::impl::send_packet_ns(EthernetII &packet) {
   port_->send_packet_ns(packet.serialize());
 }
 
+void Port::impl::subscribe_peer_parameter(const std::string &param_name,
+                                          ParameterEventCallback &callback) {
+  port_->subscribe_peer_parameter(param_name, callback);
+}
+
+void Port::impl::unsubscribe_peer_parameter(const std::string &param_name) {
+  port_->unsubscribe_peer_parameter(param_name);
+}
+
+void Port::impl::set_peer_parameter(const std::string &param_name,
+                                    const std::string &value) {
+  port_->set_peer_parameter(param_name, value);
+}
+
 PortStatus Port::impl::get_status() const {
   return port_->get_status();
 }
@@ -136,6 +156,20 @@ void Port::send_packet_out(EthernetII &packet, bool recirculate) {
 
 void Port::send_packet_ns(EthernetII &packet) {
   return pimpl_->send_packet_ns(packet);
+}
+
+void Port::subscribe_peer_parameter(const std::string &param_name,
+                                    ParameterEventCallback &callback) {
+  return pimpl_->subscribe_peer_parameter(param_name, callback);
+}
+
+void Port::unsubscribe_peer_parameter(const std::string &param_name) {
+  return pimpl_->unsubscribe_peer_parameter(param_name);
+}
+
+void Port::set_peer_parameter(const std::string &param_name,
+                              const std::string &value) {
+  return pimpl_->set_peer_parameter(param_name, value);
 }
 
 int Port::index() const {

--- a/src/libs/polycube/src/transparent_cube.cpp
+++ b/src/libs/polycube/src/transparent_cube.cpp
@@ -60,11 +60,6 @@ TransparentCube::~TransparentCube() {
   factory_->destroy_cube(get_name());
 }
 
-std::string TransparentCube::get_parent_parameter(
-    const std::string &parameter) {
-  return cube_->get_parent_parameter(parameter);
-}
-
 void TransparentCube::send_packet_out(EthernetII &packet, Sense sense,
                                       bool recirculate) {
   cube_->send_packet_out(packet.serialize(), sense, recirculate);
@@ -79,6 +74,21 @@ nlohmann::json TransparentCube::to_json() const  {
 }
 
 void TransparentCube::attach() {}
+
+void TransparentCube::subscribe_parent_parameter(
+    const std::string &param_name, ParameterEventCallback &callback) {
+  cube_->subscribe_parent_parameter(param_name, callback);
+}
+
+void TransparentCube::unsubscribe_parent_parameter(
+    const std::string &param_name) {
+  cube_->unsubscribe_parent_parameter(param_name);
+}
+
+std::string TransparentCube::get_parent_parameter(
+    const std::string &param_name) {
+  return cube_->get_parent_parameter(param_name);
+}
 
 }  // namespace service
 }  // namespace polycube

--- a/src/polycubed/src/extiface.h
+++ b/src/polycubed/src/extiface.h
@@ -24,8 +24,10 @@
 
 #include "peer_iface.h"
 #include "polycube/services/cube_iface.h"
+#include "polycube/services/utils.h"
 
 using polycube::service::ProgramType;
+using polycube::service::ParameterEventCallback;
 
 namespace polycube {
 namespace polycubed {
@@ -43,14 +45,32 @@ class ExtIface : public PeerIface {
   uint16_t get_port_id() const override;
   void set_peer_iface(PeerIface *peer) override;
   PeerIface *get_peer_iface() override;
-  std::string get_parameter(const std::string &parameter) override;
 
   void set_next_index(uint16_t index);
   bool is_used() const;
 
   std::string get_iface_name() const;
 
+  void subscribe_parameter(const std::string &caller,
+                           const std::string &param_name,
+                           ParameterEventCallback &callback) override;
+  void unsubscribe_parameter(const std::string &caller,
+                             const std::string &param_name) override;
+  std::string get_parameter(const std::string &param_name) override;
+  void set_parameter(const std::string &param_name,
+                     const std::string &value) override;
+
  protected:
+  // 2 maps: one for IP events and one for MAC events
+  // The key is the uuid of the caller
+  // The value is the pair <callback function, netlink id>
+  std::map<std::string, std::pair<ParameterEventCallback, int>>
+           parameter_ip_event_callbacks;
+  std::map<std::string, std::pair<ParameterEventCallback, int>>
+           parameter_mac_event_callbacks;
+
+  std::mutex event_mutex;
+
   static std::set<std::string> used_ifaces;
   int load_ingress();
   int load_egress();
@@ -70,6 +90,7 @@ class ExtIface : public PeerIface {
 
   ebpf::BPF tx_;
   std::string iface_;
+  unsigned int ifindex_iface;
   PeerIface *peer_;  // the interface is connected to
 
   uint16_t index_;

--- a/src/polycubed/src/peer_iface.h
+++ b/src/polycubed/src/peer_iface.h
@@ -24,6 +24,7 @@
 
 using polycube::service::TransparentCubeIface;
 using polycube::service::ProgramType;
+using polycube::service::ParameterEventCallback;
 
 namespace polycube {
 namespace polycubed {
@@ -38,7 +39,14 @@ class PeerIface {
   virtual void set_peer_iface(PeerIface *peer) = 0;
   virtual PeerIface *get_peer_iface() = 0;
 
-  virtual std::string get_parameter(const std::string &parameter) = 0;
+  virtual void subscribe_parameter(const std::string &caller,
+                                   const std::string &param_name,
+                                   ParameterEventCallback &callback) = 0;
+  virtual void unsubscribe_parameter(const std::string &caller,
+                                     const std::string &param_name) = 0;
+  virtual std::string get_parameter(const std::string &param_name) = 0;
+  virtual void set_parameter(const std::string &param_name,
+                             const std::string &value) = 0;
 
   void add_cube(TransparentCube *cube, const std::string &position,
                 const std::string &other);

--- a/src/polycubed/src/polycubed_core.h
+++ b/src/polycubed/src/polycubed_core.h
@@ -29,6 +29,7 @@
 #include "service_controller.h"
 
 #include "cube_factory_impl.h"
+#include "port.h"
 //#include "extiface_info.h"
 
 using json = nlohmann::json;
@@ -72,12 +73,26 @@ class PolycubedCore {
   void set_polycubeendpoint(std::string &polycube);
   std::string get_polycubeendpoint();
 
+  void cube_port_parameter_subscribe(
+    const std::string &cube, const std::string &port_name,
+    const std::string &caller, const std::string &parameter,
+    ParameterEventCallback &cb);
+
+  void cube_port_parameter_unsubscribe(
+    const std::string &cube, const std::string &port_name,
+    const std::string &caller, const std::string &parameter);
+
   std::string get_cube_port_parameter(const std::string &cube,
                                       const std::string &port_name,
                                       const std::string &parameter);
   std::string set_cube_parameter(const std::string &cube,
                                  const std::string &parameter,
                                  const std::string &value);
+
+  void notify_port_subscribers(const std::string &cube,
+                               const std::string &port_name,
+                               const std::string &parameter,
+                               const std::string &value);
 
   std::vector<std::string> get_all_ports();
 
@@ -87,6 +102,15 @@ class PolycubedCore {
 
  private:
   bool try_to_set_peer(const std::string &peer1, const std::string &peer2);
+
+  // map of maps of callbacks
+  // key of outer map is cube_name:port_name:param_name
+  // key of the inner map is the calle id
+  std::unordered_map<std::string,
+      std::unordered_map<std::string, ParameterEventCallback>>
+      cubes_port_event_callbacks_;
+
+  std::mutex cubes_port_event_mutex_;
 
   std::unordered_map<std::string, ServiceController> servicectrls_map_;
   std::string polycubeendpoint_;

--- a/src/polycubed/src/port.cpp
+++ b/src/polycubed/src/port.cpp
@@ -342,12 +342,14 @@ void Port::set_peer_parameter(const std::string &param_name,
 void Port::subscribe_parameter(const std::string &caller,
                                const std::string &param_name,
                                ParameterEventCallback &callback) {
-  throw std::runtime_error("subscribe_parameter not implemented in port");
+  core->cube_port_parameter_subscribe(parent_.get_name(), name_, caller,
+                                      param_name, callback);
 }
 
 void Port::unsubscribe_parameter(const std::string &caller,
                                  const std::string &param_name) {
-  throw std::runtime_error("unsubscribe_parameter not implemented in port");
+  core->cube_port_parameter_unsubscribe(parent_.get_name(), name_, caller,
+                                        param_name);
 }
 
 std::string Port::get_parameter(const std::string &param_name) {

--- a/src/polycubed/src/port.h
+++ b/src/polycubed/src/port.h
@@ -31,6 +31,7 @@
 using polycube::service::CubeIface;
 using polycube::service::PortStatus;
 using polycube::service::PortType;
+using polycube::service::ParameterEventCallback;
 
 namespace polycube {
 namespace polycubed {
@@ -57,7 +58,6 @@ class Port : public polycube::service::PortIface, public PeerIface {
   void set_next_index(uint16_t index) override;
   void set_peer_iface(PeerIface *peer) override;
   PeerIface *get_peer_iface() override;
-  std::string get_parameter(const std::string &parameter) override;
 
   // TODO: rename this
   uint16_t index() const;
@@ -79,6 +79,23 @@ class Port : public polycube::service::PortIface, public PeerIface {
 
   static void connect(PeerIface &p1, PeerIface &p2);
   static void unconnect(PeerIface &p1, PeerIface &p2);
+
+  // Implementation of parameter subscription in PeerIface.
+  void subscribe_parameter(const std::string &caller,
+                           const std::string &param_name,
+                           ParameterEventCallback &callback) override;
+  void unsubscribe_parameter(const std::string &caller,
+                             const std::string &param_name) override;
+  std::string get_parameter(const std::string &param_name) override;
+  void set_parameter(const std::string &param_name,
+                     const std::string &value) override;
+
+  // API exposed to services (PortIface)
+  void subscribe_peer_parameter(const std::string &param_name,
+                                ParameterEventCallback &callback);
+  void unsubscribe_peer_parameter(const std::string &param_name);
+  void set_peer_parameter(const std::string &param_name,
+                          const std::string &value);
 
  protected:
   void update_indexes() override;
@@ -103,6 +120,9 @@ class Port : public polycube::service::PortIface, public PeerIface {
  private:
   uint16_t port_index_; // ebpf id used by other modules to call this port
   uint16_t calculate_index() const;
+
+  std::unordered_map<std::string, ParameterEventCallback> subscription_list;
+  std::mutex subscription_list_mutex;
 };
 
 }  // namespace polycubed

--- a/src/polycubed/src/transparent_cube.h
+++ b/src/polycubed/src/transparent_cube.h
@@ -19,6 +19,7 @@
 #include "base_cube.h"
 
 using polycube::service::TransparentCubeIface;
+using polycube::service::ParameterEventCallback;
 
 namespace polycube {
 namespace polycubed {
@@ -37,13 +38,17 @@ class TransparentCube : public BaseCube, public TransparentCubeIface {
   void set_next(uint16_t next, ProgramType type);
   void set_parent(PeerIface *parent);
   PeerIface *get_parent();
-  std::string get_parent_parameter(const std::string &parameter);
   void set_parameter(const std::string &parameter, const std::string &value);
   void send_packet_out(const std::vector<uint8_t> &packet, service::Sense sense,
                        bool recirculate = false);
 
   void set_conf(const nlohmann::json &conf);
   nlohmann::json to_json() const;
+
+  void subscribe_parent_parameter(const std::string &param_name,
+                                  ParameterEventCallback &callback);
+  void unsubscribe_parent_parameter(const std::string &param_name);
+  std::string get_parent_parameter(const std::string &param_name);
 
  protected:
   void uninit();
@@ -52,6 +57,9 @@ class TransparentCube : public BaseCube, public TransparentCubeIface {
   static std::string get_wrapper_code();
   uint16_t ingress_next_;
   uint16_t egress_next_;
+
+  std::unordered_map<std::string, ParameterEventCallback> subscription_list;
+  std::mutex subscription_list_mutex;
 };
 
 }  // namespace polycubed

--- a/src/polycubed/src/utils/netlink.cpp
+++ b/src/polycubed/src/utils/netlink.cpp
@@ -24,8 +24,12 @@
 #include <sstream>
 #include <sys/socket.h>
 #include <netinet/ether.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <ifaddrs.h>
 
 #include "../exceptions.h"
+#include "polycube/services/utils.h"
 
 #ifndef SOL_NETLINK
 #define SOL_NETLINK 270
@@ -456,7 +460,6 @@ int Netlink::get_iface_index(const std::string &iface) {
   }
 
   if (!(link = rtnl_link_get_by_name(cache, iface.c_str()))) {
-    std::cout << " error" << std::endl;
     return -1;
   }
 
@@ -829,7 +832,8 @@ void Netlink::set_iface_mac(const std::string &iface, const std::string &mac) {
   nl_close(sk);
 }
 
-void Netlink::set_iface_ip(const std::string &iface, const std::string &ip, int prefix) {
+void Netlink::add_iface_ip(const std::string &iface, const std::string &ip,
+                           int prefix) {
   struct nlmsghdr *nlmsg = netlink_ip_alloc();
   struct nl_ipreq *uni = (struct nl_ipreq *)nlmsg;
   struct rtattr *rta;
@@ -837,8 +841,7 @@ void Netlink::set_iface_ip(const std::string &iface, const std::string &ip, int 
 
   int index = get_iface_index(iface);
   if (index == -1) {
-    logger->error("set_iface_ip: iface {0} does not exist", iface);
-    throw std::runtime_error("set_iface_ip: iface does not exist");
+    throw std::runtime_error("add_iface_ip: iface does not exist");
   }
 
   uni->ifaddrmsg.ifa_index = index;
@@ -846,8 +849,7 @@ void Netlink::set_iface_ip(const std::string &iface, const std::string &ip, int 
 
   if (inet_pton(AF_INET, ip.c_str(), &ia) <= 0) {
     free(nlmsg);
-    logger->error("set_iface_ip: Error in inet_pton");
-    throw std::runtime_error("set_iface_ip: Error in inet_pton");
+    throw std::runtime_error("add_iface_ip: Error in inet_pton");
   }
 
   rta = NLMSG_TAIL(nlmsg);
@@ -865,7 +867,8 @@ void Netlink::set_iface_ip(const std::string &iface, const std::string &ip, int 
   netlink_nl_send(nlmsg);
 }
 
-void Netlink::unset_iface_ip(const std::string &iface, const std::string &ip, int prefix) {
+void Netlink::delete_iface_ip(const std::string &iface, const std::string &ip,
+                              int prefix) {
   struct nlmsghdr *nlmsg = netlink_ip_dealloc();
   struct nl_ipreq *uni = (struct nl_ipreq *)nlmsg;
   struct rtattr *rta;
@@ -873,8 +876,7 @@ void Netlink::unset_iface_ip(const std::string &iface, const std::string &ip, in
 
   int index = get_iface_index(iface);
   if (index == -1) {
-    logger->error("unset_iface_ip: iface {0} does not exist", iface);
-    throw std::runtime_error("unset_iface_ip: iface does not exist");
+    throw std::runtime_error("delete_iface_ip: iface does not exist");
   }
 
   uni->ifaddrmsg.ifa_index = index;
@@ -882,8 +884,7 @@ void Netlink::unset_iface_ip(const std::string &iface, const std::string &ip, in
 
   if (inet_pton(AF_INET, ip.c_str(), &ia) <= 0) {
     free(nlmsg);
-    logger->error("unset_iface_ip: Error in inet_pton");
-    throw std::runtime_error("unset_iface_ip: Error in inet_pton");
+    throw std::runtime_error("delete_iface_ip: Error in inet_pton");
   }
 
   rta = NLMSG_TAIL(nlmsg);
@@ -901,7 +902,8 @@ void Netlink::unset_iface_ip(const std::string &iface, const std::string &ip, in
   netlink_nl_send(nlmsg);
 }
 
-void Netlink::set_iface_ipv6(const std::string &iface, const std::string &ipv6) {
+void Netlink::add_iface_ipv6(const std::string &iface,
+                             const std::string &ipv6) {
   struct nlmsghdr *nlmsg = netlink_ipv6_alloc();
   struct nl_ipreq *uni = (struct nl_ipreq *)nlmsg;
   struct rtattr *rta;
@@ -909,16 +911,14 @@ void Netlink::set_iface_ipv6(const std::string &iface, const std::string &ipv6) 
 
   int index = get_iface_index(iface);
   if (index == -1) {
-    logger->error("set_iface_ipv6: iface {0} does not exist", iface);
-    throw std::runtime_error("set_iface_ipv6: iface does not exist");
+    throw std::runtime_error("add_iface_ipv6: iface does not exist");
   }
 
   uni->ifaddrmsg.ifa_index = index;
 
   if (inet_pton(AF_INET6, ipv6.c_str(), &ia) <= 0) {
     free(nlmsg);
-    logger->error("set_iface_ipv6: Error in inet_pton");
-    throw std::runtime_error("set_iface_ipv6: Error in inet_pton");
+    throw std::runtime_error("add_iface_ipv6: Error in inet_pton");
   }
 
   rta = NLMSG_TAIL(nlmsg);
@@ -956,6 +956,102 @@ void Netlink::move_iface_into_ns(const std::string &iface, int fd) {
   nlmsg->nlmsg_len = NLMSG_ALIGN(nlmsg->nlmsg_len) + RTA_ALIGN(rta->rta_len);
 
   netlink_nl_send(nlmsg);
+}
+
+std::string Netlink::get_iface_mac(const std::string &iface) {
+  unsigned char mac[IFHWADDRLEN];
+  struct ifreq ifr;
+  int fd, rv;
+
+  strcpy(ifr.ifr_name, iface.c_str());
+  fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
+  if (fd < 0) {
+    throw std::runtime_error(
+        std::string("get_iface_mac error opening socket: ") +
+        std::strerror(errno));
+  }
+  rv = ioctl(fd, SIOCGIFHWADDR, &ifr);
+  if (rv >= 0)
+    memcpy(mac, ifr.ifr_hwaddr.sa_data, IFHWADDRLEN);
+  else {
+    close(fd);
+    throw std::runtime_error(
+        std::string("get_iface_mac error determining the MAC address: ") +
+        std::strerror(errno));
+  }
+  close(fd);
+
+  uint64_t mac_;
+  memcpy(&mac_, mac, sizeof mac_);
+  return polycube::service::utils::be_uint_to_mac_string(mac_);
+}
+
+void Netlink::set_iface_cidr(const std::string &iface,
+                             const std::string &cidr) {
+  // cidr = ip_address/prefix
+  // Split the fields
+  std::istringstream split(cidr);
+  std::vector<std::string> info;
+  char split_char = '/';
+  for (std::string each; std::getline(split, each, split_char);
+       info.push_back(each));
+  std::string ip = info[0];
+  int prefix = std::stoi(info[1]);
+
+  // Remove old ip
+  std::string old_ip = get_iface_ip(iface);
+  std::string old_netmask = get_iface_netmask(iface);
+  if (!old_ip.empty() && !old_netmask.empty()) {
+    int old_prefix = polycube::service::utils::get_netmask_length(old_netmask);
+    delete_iface_ip(iface, old_ip, old_prefix);
+  }
+
+  // Add new ip
+  add_iface_ip(iface, ip, prefix);
+}
+
+std::string Netlink::get_iface_ip(const std::string &iface) {
+  std::string ipAddress = "";
+  struct ifaddrs *interfaces = NULL;
+  struct ifaddrs *temp_addr = NULL;
+  int success = getifaddrs(&interfaces);
+  if (success == 0) {
+    // Loop through linked list of interfaces
+    temp_addr = interfaces;
+    while (temp_addr != NULL) {
+      if (temp_addr->ifa_addr->sa_family == AF_INET) {
+        if (temp_addr->ifa_name == iface)
+          ipAddress =
+              inet_ntoa(((struct sockaddr_in*)temp_addr->ifa_addr)->sin_addr);
+      }
+      temp_addr = temp_addr->ifa_next;
+    }
+  }
+  // Free memory
+  freeifaddrs(interfaces);
+  return ipAddress;
+}
+
+std::string Netlink::get_iface_netmask(const std::string &iface) {
+  std::string netmask = "";
+  struct ifaddrs *interfaces = NULL;
+  struct ifaddrs *temp_addr = NULL;
+  int success = getifaddrs(&interfaces);
+  if (success == 0) {
+    // Loop through linked list of interfaces
+    temp_addr = interfaces;
+    while (temp_addr != NULL) {
+      if (temp_addr->ifa_addr->sa_family == AF_INET) {
+        if (temp_addr->ifa_name == iface)
+          netmask = inet_ntoa(
+              ((struct sockaddr_in*)temp_addr->ifa_netmask)->sin_addr);
+      }
+      temp_addr = temp_addr->ifa_next;
+    }
+  }
+  // Free memory
+  freeifaddrs(interfaces);
+  return netmask;
 }
 
 }  // namespace polycubed

--- a/src/polycubed/src/utils/netlink.h
+++ b/src/polycubed/src/utils/netlink.h
@@ -79,10 +79,16 @@ class Netlink {
 
   void set_iface_status(const std::string &iface, IFACE_STATUS status);
   void set_iface_mac(const std::string &iface, const std::string &mac);
-  void set_iface_ip(const std::string &iface, const std::string &ip, int prefix);
-  void unset_iface_ip(const std::string &iface, const std::string &ip, int prefix);
-  void set_iface_ipv6(const std::string &iface, const std::string &ip);
+  std::string get_iface_mac(const std::string &iface);
+  void add_iface_ip(const std::string &iface, const std::string &ip, int prefix);
+  void add_iface_ipv6(const std::string &iface, const std::string &ip);
+  std::string get_iface_ip(const std::string &iface);
+  std::string get_iface_netmask(const std::string &iface);
+  void delete_iface_ip(const std::string &iface, const std::string &ip, int prefix);
   void move_iface_into_ns(const std::string &iface, int fd);
+
+  // Remove old ip address and add new ip address
+  void set_iface_cidr(const std::string &iface, const std::string &cidr);
 
   template <typename Observer>
   int registerObserver(const Event &event, Observer &&observer) {

--- a/src/polycubed/src/utils/veth.cpp
+++ b/src/polycubed/src/utils/veth.cpp
@@ -71,23 +71,27 @@ void VethPeer::set_mac(const std::string &mac) {
 
 void VethPeer::set_ip(const std::string &ip, const int prefix) {
   if (!ns_.empty()) {
-    /* exec set_iface_ip into namespace */
-    std::function<void()> doThis = [&]{Netlink::getInstance().set_iface_ip(name_, ip, prefix);};
+    /* exec add_iface_ip into namespace */
+    std::function<void()> doThis = [&]{
+      Netlink::getInstance().add_iface_ip(name_, ip, prefix);
+    };
     Namespace namespace_ = Namespace::open(ns_);
     namespace_.execute(doThis);
   } else {
-    Netlink::getInstance().set_iface_ip(name_, ip, prefix);
+    Netlink::getInstance().add_iface_ip(name_, ip, prefix);
   }
 }
 
 void VethPeer::set_ipv6(const std::string &ipv6) {
   if (!ns_.empty()) {
-    /* exec set_iface_ipv6 into namespace */
-    std::function<void()> doThis = [&]{Netlink::getInstance().set_iface_ipv6(name_, ipv6);};
+    /* exec add_iface_ipv6 into namespace */
+    std::function<void()> doThis = [&]{
+      Netlink::getInstance().add_iface_ipv6(name_, ipv6);
+    };
     Namespace namespace_ = Namespace::open(ns_);
     namespace_.execute(doThis);
   } else {
-    Netlink::getInstance().set_iface_ipv6(name_, ipv6);
+    Netlink::getInstance().add_iface_ipv6(name_, ipv6);
   }
 }
 

--- a/src/services/pcn-nat/src/Nat.h
+++ b/src/services/pcn-nat/src/Nat.h
@@ -68,8 +68,6 @@ class Nat : public polycube::service::TransparentCube, public NatInterface {
                  polycube::service::PacketInMetadata &md,
                  const std::vector<uint8_t> &packet) override;
 
-  void attach() override;
-
   /// <summary>
   ///
   /// </summary>

--- a/src/services/pcn-router/src/Ports.cpp
+++ b/src/services/pcn-router/src/Ports.cpp
@@ -149,7 +149,9 @@ void Ports::setIp(const std::string &value) {
     // unset old ip
     if (parent_.get_shadow()) {
       int prefix = get_netmask_length(getNetmask());
-      std::function<void()> doThis = [&]{parent_.netlink_instance_router_.unset_iface_ip(getName(), ip_, prefix);};
+      std::function<void()> doThis = [&]{
+        parent_.netlink_instance_router_.delete_iface_ip(getName(), ip_, prefix);
+      };
       polycube::polycubed::Namespace namespace_ = polycube::polycubed::Namespace::open("pcn-" + parent_.get_name());
       namespace_.execute(doThis);
     }
@@ -159,7 +161,9 @@ void Ports::setIp(const std::string &value) {
     // set new ip
     if (parent_.get_shadow()) {
       int prefix = get_netmask_length(getNetmask());
-      std::function<void()> doThis = [&]{parent_.netlink_instance_router_.set_iface_ip(getName(), value, prefix);};
+      std::function<void()> doThis = [&]{
+        parent_.netlink_instance_router_.add_iface_ip(getName(), value, prefix);
+      };
       polycube::polycubed::Namespace namespace_ = polycube::polycubed::Namespace::open("pcn-" + parent_.get_name());
       namespace_.execute(doThis);
     }
@@ -204,7 +208,9 @@ void Ports::setNetmask(const std::string &value) {
     // unset old netmask
     if (parent_.get_shadow()) {
       int prefix = get_netmask_length(netmask_);
-      std::function<void()> doThis = [&]{parent_.netlink_instance_router_.unset_iface_ip(getName(), ip_, prefix);};
+      std::function<void()> doThis = [&]{
+        parent_.netlink_instance_router_.delete_iface_ip(getName(), ip_, prefix);
+      };
       polycube::polycubed::Namespace namespace_ = polycube::polycubed::Namespace::open("pcn-" + parent_.get_name());
       namespace_.execute(doThis);
     }
@@ -214,7 +220,9 @@ void Ports::setNetmask(const std::string &value) {
     // set new netmask
     if (parent_.get_shadow()) {
       int prefix = get_netmask_length(value);
-      std::function<void()> doThis = [&]{parent_.netlink_instance_router_.set_iface_ip(getName(), getIp(), prefix);};
+      std::function<void()> doThis = [&]{
+        parent_.netlink_instance_router_.add_iface_ip(getName(), getIp(), prefix);
+      };
       polycube::polycubed::Namespace namespace_ = polycube::polycubed::Namespace::open("pcn-" + parent_.get_name());
       namespace_.execute(doThis);
     }

--- a/src/services/pcn-router/src/Ports.h
+++ b/src/services/pcn-router/src/Ports.h
@@ -74,6 +74,7 @@ class Ports : public polycube::service::Port, public PortsInterface {
   /// </summary>
   std::string getMac() override;
   void setMac(const std::string &value) override;
+  void doSetMac(const std::string &value);
 
   /// <summary>
   /// Secondary IP address for the port


### PR DESCRIPTION
This PR adds:

A. The methods to align a port or a transparent cube with a netdev, when they are connected to each other.
The methods added are:
1) `subscribe_parameter(caller, parameter, callback function)` = subscribe the port or the transparent cube to the change of the parameter. If the netdev changes that parameter it is called the callback function.
2) `unsubscribe_parameter(caller, parameter)` = cancel the subscription of the port or the transparent cube by changing the parameter.
3) `set_parameter(parameter, value)` = update the parameter on the netdev with the new value.

B. The methods to align the parameters between a transparent cube and a port, when the cube is attached to the port.
The methods in this case are:
4) `subscribe_parent_parameter(parameter, callback function)`.
5) `unsubscribe_parent_parameter(parameter)`.

C. The router ports are extended because when a port is connected to a netdev, the parameters between port and netdev automatically align (same MAC, same IP and same Netmask)