### PR TITLE
Update AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,9 +4,12 @@ off on commits in the Polycube repository:
   Aasif Shaikh                            aasif@shaikh.cc
   Francesco Messina                       francescomessina92@hotmail.com
   Fulvio Risso                            fulvio.risso@polito.it
+  Gianluca Scopelliti                     gianlu.1033@gmail.com
   Jianwen Pi                              jianwpi@gmail.com
   Matteo Bertrone                         m.bertrone@gmail.com
   Mauricio Vásquez Bernal                 mauriciovasquezbernal@gmail.com
+  Nico Caprioli                           nico.caprioli@gmail.com
+  Riccardo Marchi                         riccardo.marchi4@gmail.com
   Sebastiano Miano                        mianosebastiano@gmail.com
   Yunsong Lu                              roamer@yunsong.lu
 


### PR DESCRIPTION
Added Riccardo Marchi (added stateful capabilities to polycubed), Gianluca Scopelliti (updated and improved the bridge service) and Nico Caprioli (parsing of YANG datamodels at run-time and dynamic update of the REST web server).

Signed-off-by: Fulvio Risso <fulvio.risso@polito.it>