### PR TITLE
pcn-iptables: fix wrong const type

### DIFF
--- a/src/services/pcn-firewall/src/defines.h
+++ b/src/services/pcn-firewall/src/defines.h
@@ -105,7 +105,7 @@ namespace HorusConst {
 
 // apply Horus mitigator optimization if there are at least # rules
 // matching the pattern, at ruleset begin
-    const uint8_t MIN_RULE_SIZE_FOR_HORUS = 1;
+    const uint32_t MIN_RULE_SIZE_FOR_HORUS = 1;
     const uint32_t MAX_RULE_SIZE_FOR_HORUS = 2048;
 }
 

--- a/src/services/pcn-iptables/src/defines.h
+++ b/src/services/pcn-iptables/src/defines.h
@@ -123,8 +123,8 @@ const uint8_t DSTPORT = 4;
 
 // apply Horus mitigator optimization if there are at least # rules
 // matching the pattern, at ruleset begin
-const uint8_t MIN_RULE_SIZE_FOR_HORUS = 1;
-const uint8_t MAX_RULE_SIZE_FOR_HORUS = 2048;
+const uint32_t MIN_RULE_SIZE_FOR_HORUS = 1;
+const uint32_t MAX_RULE_SIZE_FOR_HORUS = 2048;
 
 // Enable Horus optimization
 // We want to disable Horus by default while we decide a policy to apply it or


### PR DESCRIPTION
wrong const type was committed by mistake during porting of HORUS functionalities.
This PR fixes this issue.