### PR TITLE
load old topology at startup and save each modification to file

### DIFF
--- a/Documentation/polycubed/polycubed.rst
+++ b/Documentation/polycubed/polycubed.rst
@@ -78,6 +78,35 @@ If the same parameter is specified in both, the configuration file and the comma
     daemon: true
     #p: 6000 <-- this is NOT supported, only long options are
 
+
+
+Persistency
+^^^^^^^^^^^
+
+Polycubed has persistent capabilities which means that (1) it can automatically load the configuration that was present when the daemon was shut down, (2) each time a configuration command is issued, it is automatically dumped on disk.
+This allows polycubed also to recover from failures, such as rebooting the machine.
+To enable this feature we need to start polycubed with the ``--cubes-dump-enable`` flag.
+The daemon keeps in memory an instance of all the topology, including the configuration of each individual service.
+Topology and configuration are automatically updated at each new command; the configuration is also dumped to disk, on file ``/etc/polycube/cubes.yaml``.
+The standard behavior of the daemon at startup is to load, if present, the latest topology that was active at the end of the previous execution.
+Users can load a different topology file by using the ``--cubes-dump-file`` flag followed by the path to the file.
+In case we want to start polycubed with an empty topology, avoiding any possible load at startup, we can launch polycubed with the ``--cubes-dump-clean-init`` flag. Beware that in this case any existing configuration in the default file will be overwritten.
+``--cubes-dump-enable`` is required if we want to use any of the other two related flags.
+There are some limitations: (1) YANG actions, such as "append" for firewall and nat rules, are not supported, (2) some services fail to load the full configuration at once and (3) transparent services attached to netdevs are not saved in the cubes dump file.
+
+::
+
+    # start daemon with topology saving functionalities
+    polycubed --cubes-dump-enable
+
+    # start polycubed with custom cubes configuration
+    polycubed --cubes-dump-enable --cubes-dump-file ~/Desktop/myCubes.yaml
+
+    # start polycubed with an empty topology
+    polycubed --cubes-dump-enable --cubes-dump-clean-init
+
+
+
 Rest API
 ^^^^^^^^
 

--- a/src/polycubed/src/CMakeLists.txt
+++ b/src/polycubed/src/CMakeLists.txt
@@ -62,6 +62,7 @@ set(polycubed_sources
   utils/veth.cpp
   utils/netlink.cpp
   utils/utils.cpp
+  cubes_dump.cpp
   ${server_sources}
   ${CMAKE_CURRENT_BINARY_DIR}/load_services.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/version.cpp)

--- a/src/polycubed/src/config.h
+++ b/src/polycubed/src/config.h
@@ -53,6 +53,22 @@ class Config {
   std::string getLogFile() const;
   void setLogFile(const std::string &value);
 
+  // file where last topology is saved
+  std::string getCubesDumpFile() const;
+  void setCubesDumpFile(const std::string &value);
+
+  // set to get an empty topology
+  bool getCubesDumpCleanInit() const;
+  void setCubesDumpCleanInit();
+
+  // set to avoid daemon to dump updates to file
+  //bool getCubesNoDump() const;
+  //void setCubesNoDump();
+
+  // set to let daemon to dump updates to file
+  bool getCubesDumpEnabled() const;
+  void setCubesDumpEnabled();
+
   // path of certificate & key to be used in server
   std::string getCertPath() const;
   void setCertPath(const std::string &value);
@@ -80,11 +96,17 @@ class Config {
 
   spdlog::level::level_enum loglevel;
   bool daemon;
+  bool cubes_dump_clean_init;
+  //bool cubes_nodump;
+  bool cubes_dump_enabled;
+  // true if --cubes-dump-file flag is used
+  bool cubes_dump_file_flag;
   std::string pidfile;
   uint16_t server_port;
   std::string server_ip;
   std::string logfile;
   std::string configfile;
+  std::string cubes_dump_file;
   std::string cert_path, key_path;
   std::string cacert_path;
   std::string cert_whitelist_path;

--- a/src/polycubed/src/cubes_dump.cpp
+++ b/src/polycubed/src/cubes_dump.cpp
@@ -1,0 +1,518 @@
+/*
+ * Copyright 2019 The Polycube Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fstream>
+#include "cubes_dump.h"
+#include "config.h"
+#include "rest_server.h"
+#include "server/Resources/Body/ListKey.h"
+#include "server/Resources/Endpoint/Resource.h"
+
+namespace polycube::polycubed {
+
+using Rest::Resources::Body::ListKey;
+using Rest::Resources::Endpoint::Operation;
+
+CubesDump::CubesDump() : dump_enabled_(false), kill_saving_thread_(false) {
+  save_in_file_thread_ = std::make_unique<std::thread>(&CubesDump::SaveToFile,
+                           this, configuration::config.getCubesDumpFile());
+}
+
+CubesDump::~CubesDump() {
+  kill_saving_thread_ = true;
+  wait_for_update_.notify_one();
+  save_in_file_thread_->join();
+}
+
+void CubesDump::Enable() {
+  dump_enabled_ = true;
+}
+
+void CubesDump::UpdateCubesConfig(const std::string& resource,
+                              const nlohmann::json& body,
+                              const ListKeyValues &keys,
+                              Rest::Resources::Endpoint::Operation opType,
+                              Rest::Resources::Endpoint::ResourceType resType) {
+
+  std::string resourcePath = resource.substr(RestServer::base.size(),
+                                             resource.size());
+
+  std::stringstream ssResource(resourcePath);
+  std::vector<std::string> resItem;
+  std::string tokenResource;
+
+  while (std::getline(ssResource, tokenResource, '/')) { /* Get path elements */
+    resItem.push_back(tokenResource);
+  }
+
+  /*
+   * Depending on the operation, we look into the resource string, the body
+   * and the ListKeyValues to update the configuration of the cubes in the map
+   * (<cubeName, cubeConfiguration>) we have in memory.
+   * If it is not the initial topology load, the whole configuration is saved
+   * to file after each modification by a separate thread, to avoid to overload
+   * the server thread.
+   */
+  std::lock_guard<std::mutex> guardConfigMutex(cubes_config_mutex_);
+  switch (opType) {
+  case Operation::kCreate:
+  case Operation::kReplace:
+    UpdateCubesConfigCreateReplace(resItem, body, keys, resType);
+    break;
+
+  case Operation::kUpdate:
+    UpdateCubesConfigUpdate(resItem, body, keys, resType);
+    break;
+
+  case Operation::kDelete:
+    UpdateCubesConfigDelete(resItem, body, keys, resType);
+    break;
+  }
+
+  /*
+   * if the dump is enabled, notify the saving thread that an update
+   * to the topology occured and needs to be dumped to file
+   */
+  if (dump_enabled_) {
+    list_of_pending_changes_++;
+    wait_for_update_.notify_one();
+  }
+}
+
+/*
+ * This updates the configuration when the connect or disconnect commands
+ * are used, setting another cube's port as peer for a certain cube.
+ */
+void CubesDump::UpdatePortPeer(const std::string& cubeName,
+                               const std::string& cubePort,
+                               std::string peer) {
+
+  std::lock_guard<std::mutex> guardConfigMutex(cubes_config_mutex_);
+  auto *cubePortsArray = &(cubes_config_.at(cubeName).at("ports"));
+  auto *portToConnect = &*(std::find_if(cubePortsArray->begin(),
+          cubePortsArray->end(),
+          [cubePort](auto const& elem){return elem.at("name") == cubePort;}));
+  if (peer.empty()) {
+    portToConnect->erase("peer");
+  } else {
+    nlohmann::json jsonPeer = nlohmann::json::object();
+    jsonPeer["peer"] = peer;
+    jsonPeer.update(*portToConnect);
+    portToConnect->clear();
+    portToConnect->update(jsonPeer);
+  }
+
+  /*
+   * if the dump is enabled, notify the saving thread that an update
+   * to the topology occured and needs to be dumped to file
+   */
+  if (dump_enabled_) {
+    list_of_pending_changes_++;
+    wait_for_update_.notify_one();
+  }
+}
+
+/*
+ * This updates the configuration when the attach or detach special commands
+ * are used, adding or removing transparent cubes from other cubes' ports.
+ */
+void CubesDump::UpdatePortTCubes(const std::string& cubeName,
+                                 const std::string& cubePort,
+                                 std::string tCubeName,
+                                 int position) {
+
+  std::lock_guard<std::mutex> guardConfigMutex(cubes_config_mutex_);
+  auto *cubePortsArray = &(cubes_config_.at(cubeName).at("ports"));
+  auto *interestedPort = &*(std::find_if(cubePortsArray->begin(),
+          cubePortsArray->end(),
+          [cubePort](auto const& elem){return elem.at("name") == cubePort;}));
+  if (position == -1) {
+    auto toDetach = std::find(interestedPort->at("tcubes").begin(),
+            interestedPort->at("tcubes").end(), tCubeName);
+    interestedPort->at("tcubes").erase(toDetach);
+    if (interestedPort->at("tcubes").empty()) {
+      interestedPort->erase("tcubes");
+    }
+  } else {
+    nlohmann::json element; /*workaround to bypass nlohmann::json library bug*/
+    element.update(*interestedPort);
+    if (element["tcubes"].is_null()) {
+      std::vector<std::string> tCubesArray;
+      tCubesArray.push_back(tCubeName);
+      nlohmann::json completeObject = nlohmann::json::object();
+      completeObject["tcubes"] = tCubesArray;
+      completeObject.update(*interestedPort);
+      interestedPort->clear();
+      interestedPort->update(completeObject);
+    } else {
+      interestedPort->at("tcubes").insert(
+              interestedPort->at("tcubes").begin() + position, tCubeName);
+    }
+  }
+
+  /*
+   * if the dump is enabled, notify the saving thread that an update
+   * to the topology occured and needs to be dumped to file
+   */
+  if (dump_enabled_) {
+    list_of_pending_changes_++;
+    wait_for_update_.notify_one();
+  }
+}
+
+/*
+ * This adds or replaces a cube or a cube's resource
+ */
+void CubesDump::UpdateCubesConfigCreateReplace(
+                            const std::vector<std::string> &resItem,
+                            const nlohmann::json& body,
+                            const ListKeyValues &keys,
+                            Rest::Resources::Endpoint::ResourceType resType) {
+
+  const std::string &serviceName = resItem[0];
+  const std::string &cubeName = resItem[1];
+
+  // map saving key values corresponding to proper list name
+  std::map<std::string, std::vector<Rest::Resources::Body::ListKeyValue>> keyValues;
+  for (auto &key : keys) {
+    keyValues[key.list_element].push_back(key);
+  }
+
+  switch (resType) {
+  case Rest::Resources::Endpoint::ResourceType::Service: {
+    nlohmann::json serviceField = nlohmann::json::object();
+    serviceField["service-name"] = serviceName;
+    serviceField.update(body);
+    if (cubes_config_.find(cubeName) != cubes_config_.end()) {
+      cubes_config_.at(cubeName).clear();
+    }
+    cubes_config_[cubeName].update(serviceField);
+    break;
+  }
+
+  case Rest::Resources::Endpoint::ResourceType::ParentResource:
+  case Rest::Resources::Endpoint::ResourceType::ListResource: {
+    nlohmann::json *item = &cubes_config_[cubeName];
+    for (int i = 2; i < resItem.size() - 1; i++) {
+      nlohmann::json element;/*workaround to bypass nlohmann::json library bug*/
+      element.update(*item);
+      auto *reference = &(*item)[resItem[i]];
+      if (element[resItem[i]].is_null()) { /* is element present? */
+        if (!keys.empty() && keyValues.find(resItem[i]) != keyValues.end()) { /* is it a missing array? */
+          if (i >= resItem.size() - 1 - keyValues.at(resItem[i]).size()) { /* is it the last? */
+            nlohmann::json toUpdate = nlohmann::json::array();
+            toUpdate.push_back(body);
+            nlohmann::json completeObj;
+            completeObj[resItem[i]] = toUpdate;
+            element.update(completeObj);
+            *item = element;
+            break;
+          } else {
+            nlohmann::json newArrayItem = nlohmann::json::object();
+            for (auto &keyValue : keyValues.at(resItem[i])) {
+              newArrayItem[keyValue.original_key] = keyValue.value;
+            }
+            nlohmann::json newArray = nlohmann::json::array();
+            newArray.push_back(newArrayItem);
+            nlohmann::json completeObj;
+            completeObj[resItem[i]] = newArray;
+            element.update(completeObj);
+            *item = element;
+            reference = &(*item)[resItem[i]].front();
+            i += keyValues[resItem[i]].size();
+          }
+        } else if (element.is_array()) { /* is it a missing element in the array? */
+          nlohmann::json arrayElement;
+          for (auto &keyElement : keyValues[resItem[i]]) {
+            arrayElement[keyElement.original_key] = keyElement.value;
+          }
+          reference->push_back(arrayElement);
+          reference = &(*item)[resItem[i]].back();
+          i += keyValues[resItem[i]].size();
+          if (i > resItem.size() - 2) { /* is it the last? */
+            reference->push_back(body);
+          }
+        } else { /* it is a missing element */
+          nlohmann::json missingElement = nlohmann::json::object();
+          element[resItem[i]] = missingElement;
+          *item = element;
+          reference = &(*item)[resItem[i]];
+          if (i > resItem.size() - 2) { /* is it the last? */
+            *reference = body;
+          }
+        }
+      } else if (element[resItem[i]].is_array()) { /* is it an array? */
+        auto toCreateReplace = std::find_if(reference->begin(),
+                reference->end(),
+                [resItem, i, keyValues, this](auto const& elem){
+                      return checkPresence(resItem, i, keyValues, elem);});
+        if (i + keyValues.at(resItem[i]).size() > resItem.size() - 2) { /* if it is last element of an array, we can update it */
+          if (toCreateReplace != reference->end()) {
+            reference->erase(toCreateReplace);
+          }
+          reference->push_back(body);
+        } else { /* not the last, find the element and update the reference */
+          if (toCreateReplace != reference->end()) {
+            reference = &*toCreateReplace;
+          } else {
+            nlohmann::json arrayElement;
+            for (auto &keyElement : keyValues[resItem[i]]) {
+              arrayElement[keyElement.original_key] = keyElement.value;
+            }
+            reference->push_back(arrayElement);
+            reference = &(*item)[resItem[i]].back();
+          }
+        }
+        i += keyValues[resItem[i]].size();
+      }
+      item = reference;
+    }
+    break;
+  }
+
+  case Rest::Resources::Endpoint::ResourceType::LeafResource: {
+    nlohmann::json *item = &cubes_config_[cubeName];
+    for (int i = 2; i < resItem.size() - 1; i++) {
+      auto *reference = &(*item)[resItem[i]];
+      if (reference->is_array()) { /* find array element and update reference */
+        reference = &*(std::find_if(reference->begin(), reference->end(),
+                [resItem, i, keyValues, this](auto const& elem){
+          return checkPresence(resItem, i, keyValues, elem);}));
+        i += keyValues.at(resItem[i]).size();
+      } else if (i > resItem.size() - 2) {
+        nlohmann::json toUpdate = nlohmann::json::object();
+        toUpdate[resItem[resItem.size() - 1]] = body;
+        toUpdate.insert(item->begin(), item->end());
+        item->clear();
+        item->update(toUpdate);
+      }
+      item = reference;
+    }
+    break;
+  }
+  }
+}
+
+/*
+ * This updates a cube or a cube's resource.
+ */
+void CubesDump::UpdateCubesConfigUpdate(const std::vector<std::string> &resItem,
+                            const nlohmann::json body,
+                            const ListKeyValues &keys,
+                            Rest::Resources::Endpoint::ResourceType resType) {
+
+  const std::string &serviceName = resItem[0];
+  const std::string &cubeName = resItem[1];
+
+  std::map<std::string, std::vector<Rest::Resources::Body::ListKeyValue>> keyValues;
+  for (auto &key : keys) {
+    keyValues[key.list_element].push_back(key);
+  }
+
+  if (resType == Rest::Resources::Endpoint::ResourceType::Service) {
+    nlohmann::json serviceField = nlohmann::json::object();
+    serviceField.update(body);
+    cubes_config_.at(cubeName).update(serviceField);
+  } else {
+    nlohmann::json *item = &cubes_config_[cubeName];
+    for (int i = 2; i < resItem.size() - 1; i++) {
+      nlohmann::json element; /* workaround to bypass nlohmann::json library bug */
+      element.update(*item);
+      auto *reference = &(*item)[resItem[i]];
+      if (element[resItem[i]].is_null()) {
+        if (!keys.empty() && keyValues.find(resItem[i]) != keyValues.end()) { /* is it a missing array? */
+          nlohmann::json newArray = nlohmann::json::array();
+          nlohmann::json arrayElement;
+          for (auto &keyElement : keyValues[resItem[i]]) {
+            arrayElement[keyElement.original_key] = keyElement.value;
+          }
+          newArray.push_back(arrayElement);
+          nlohmann::json completeObj;
+          completeObj[resItem[i]] = newArray;
+          element.update(completeObj);
+          *item = element;
+          reference = &(*item)[resItem[i]].front();
+          i += keyValues[resItem[i]].size();
+        } else if (element.is_array()) { /* is it a missing element in the array? */
+          nlohmann::json arrayElement;
+          for (auto &keyElement : keyValues[resItem[i]]) {
+            arrayElement[keyElement.original_key] = keyElement.value;
+          }
+          reference->push_back(arrayElement);
+          reference = &(*item)[resItem[i]].back();
+          i += keyValues[resItem[i]].size();
+        } else { /* it is a missing element */
+          nlohmann::json missingElement = nlohmann::json::object();
+          element[resItem[i]] = missingElement;
+          *item = element;
+          reference = &(*item)[resItem[i]];
+        }
+      } else if (element[resItem[i]].is_array()) { /* If it is an array corresponding to a key, then it is an element of an array */
+        if (!reference->empty()) {
+          auto elementFound = std::find_if(reference->begin(), reference->end(),
+                         [resItem, i, keyValues, this](auto const &elem) {
+                             return checkPresence(resItem, i, keyValues, elem);
+                         });
+          if (elementFound != reference->end()) { /* is the element present? */
+            reference = &*elementFound;
+          } else { /* create the missing element */
+            nlohmann::json toInsert;
+            for (auto &keyElement : keyValues[resItem[i]]) {
+              toInsert[keyElement.original_key] = keyElement.value;
+            }
+            element[resItem[i]].push_back(toInsert);
+            *item = element;
+            reference = &(*item)[resItem[i]].back();
+          }
+        } else { /* create the missing element */
+          nlohmann::json toInsert = nlohmann::json::object();
+          for (auto &keyElement : keyValues[resItem[i]]) {
+            toInsert[keyElement.original_key] = keyElement.value;
+          }
+          element[resItem[i]].push_back(toInsert);
+          *item = element;
+          reference = &(*item)[resItem[i]].back();
+        }
+        i += keyValues.at(resItem[i]).size();
+      }
+      item = reference;
+    }
+
+    nlohmann::json toUpdate = nlohmann::json::object();
+    toUpdate[resItem[resItem.size() - 1]] = body;
+    toUpdate.insert(item->begin(), item->end());
+    item->clear();
+    item->update(toUpdate);
+  }
+}
+
+/*
+ * This deletes a cube or a cube's resource.
+ */
+void CubesDump::UpdateCubesConfigDelete(const std::vector<std::string> &resItem,
+                              const nlohmann::json& body,
+                              const ListKeyValues &keys,
+                              Rest::Resources::Endpoint::ResourceType resType) {
+
+  const std::string &serviceName = resItem[0];
+  const std::string &cubeName = resItem[1];
+
+  std::map<std::string, std::vector<Rest::Resources::Body::ListKeyValue>> keyValues;
+  for (auto &key : keys) {
+    keyValues[key.list_element].push_back(key);
+  }
+
+  if (resType == Rest::Resources::Endpoint::ResourceType::Service) { /* If it regards the full service */
+    cubes_config_.erase(cubeName);
+  } else { /* If it regards an element of that service */
+    nlohmann::json *item = &cubes_config_[cubeName];
+    bool deleted = false;
+    for (int i = 2; i < resItem.size() - 1; i++) {
+      nlohmann::json element; /* workaround to bypass nlohmann::json library bug */
+      element.update(*item);
+      auto *reference = &(*item)[resItem[i]];
+      if (element[resItem[i]].is_null()) {
+        return;
+      }
+      if (element[resItem[i]].is_array()) { /* If it is an element of an array, treat it differently */
+        int actualIndex = i;
+        auto toDelete = std::find_if(reference->begin(), reference->end(),
+                [resItem, i, keyValues, this](auto const& elem){
+                    return checkPresence(resItem, i, keyValues, elem);});
+        i += keyValues.at(resItem[i]).size();
+        if (toDelete == reference->end()) {
+          return;
+        }
+        if (i > resItem.size() - 2) { /* if it is an array element, delete it now and set deleted true */
+          reference->erase(toDelete);
+          deleted = true;
+          if (reference->empty()) { /* delete if array is empty */
+            item->erase(resItem[actualIndex]);
+          }
+        } else { /* update the reference to the array elem */
+          reference = &*toDelete;
+        }
+      }
+      item = reference;
+    }
+
+    if (!deleted) {
+      if ((*item)[resItem[resItem.size() - 1]].is_null()) {
+        return;
+      }
+      item->erase(resItem[resItem.size() - 1]);
+    }
+  }
+}
+
+/*
+ * This function is called in a thread when the cube-dump option is enabled
+ */
+void CubesDump::SaveToFile(const std::string& path) {
+  while (true) {
+    // mutex with condition variable waitForUpdate on cubes_config_
+    std::unique_lock<std::mutex> cubesConfigLock(cubes_config_mutex_);
+    // retrieve the value of the atomic variable and if there are no updates from last write to file,
+    // either wait for updates (kill=false) or exit if the daemon is shutting down (kill=true)
+    if (list_of_pending_changes_.load() == 0 && !kill_saving_thread_) {
+      wait_for_update_.wait(cubesConfigLock);
+    }
+
+    if (list_of_pending_changes_.load() == 0 && kill_saving_thread_) {
+      break;
+    }
+
+    std::map<std::string, nlohmann::json> copyConfig(cubes_config_);
+    // reset to 0 the list of pending changes
+    list_of_pending_changes_.store(0);
+    cubesConfigLock.unlock();
+    std::ofstream cubesDump(path);
+
+    if (cubesDump.is_open()) {
+      nlohmann::json toDump = nlohmann::json::array();
+      for (const auto &elem : copyConfig) {
+        auto cube = elem.second;
+        toDump += cube;
+      }
+      cubesDump << toDump.dump(2);
+      cubesDump.close();
+    }
+  }
+}
+
+/*
+ * checks if an element with certain key values exists
+ */
+bool CubesDump::checkPresence(const std::vector<std::string> &resItem,
+                  const int &resItemIndex,
+                  const std::map<std::string,
+                  std::vector<Rest::Resources::Body::ListKeyValue>> &keyValues,
+                  const nlohmann::json &elem) {
+  int valuesNumber = keyValues.at(resItem[resItemIndex]).size();
+  int index = 0;
+
+  for (auto &element : keyValues.at(resItem[resItemIndex])) {
+    if (elem[keyValues.at(resItem[resItemIndex])[index].original_key]
+          == resItem[resItemIndex + index + 1]) {
+      valuesNumber--;
+      index++;
+    }
+  }
+
+  return valuesNumber == 0;
+}
+
+} // namespace polycube::polycubed

--- a/src/polycubed/src/cubes_dump.h
+++ b/src/polycubed/src/cubes_dump.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 The Polycube Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <polycube/services/json.hpp>
+#include <server/Resources/Body/ListKey.h>
+#include <server/Resources/Endpoint/Resource.h>
+
+namespace polycube::polycubed {
+
+class CubesDump {
+ public:
+  CubesDump();
+  ~CubesDump();
+
+  void Enable();
+
+  void UpdateCubesConfig(const std::string &resource,
+                         const nlohmann::json &body,
+                         const ListKeyValues &keys,
+                         Rest::Resources::Endpoint::Operation opType,
+                         Rest::Resources::Endpoint::ResourceType resType);
+
+  void UpdatePortPeer(const std::string& cubeName,
+          const std::string& cubePort,
+          std::string peer);
+
+  void UpdatePortTCubes(const std::string& cubeName,
+          const std::string& cubePort,
+          std::string tCubeName,
+          int position);
+
+ private:
+  void UpdateCubesConfigCreateReplace(const std::vector<std::string> &resItem,
+                              const nlohmann::json &body,
+                              const ListKeyValues &keys,
+                              Rest::Resources::Endpoint::ResourceType resType);
+
+  void UpdateCubesConfigUpdate(const std::vector<std::string> &resItem,
+                               const nlohmann::json body,
+                               const ListKeyValues &keys,
+                               Rest::Resources::Endpoint::ResourceType resType);
+
+  void UpdateCubesConfigDelete(const std::vector<std::string> &resItem,
+                               const nlohmann::json &body,
+                               const ListKeyValues &keys,
+                               Rest::Resources::Endpoint::ResourceType resType);
+
+  bool checkPresence(const std::vector<std::string> &resItem,
+                   const int &resItemIndex,
+                   const std::map<std::string,
+                   std::vector<Rest::Resources::Body::ListKeyValue>> &keyValues,
+                   const nlohmann::json &elem);
+
+  void SaveToFile(const std::string &path);
+
+  // thread that saves in file
+  std::unique_ptr<std::thread> save_in_file_thread_;
+  // mutex on the access to cubesConfig
+  std::mutex cubes_config_mutex_;
+  // cubes configuration <name, configuration>
+  std::map<std::string, nlohmann::json> cubes_config_;
+  // how many updates have been made while thread saving to file.
+  // it is incremented by the server to notify when an update is available while
+  // the saving thread was not waiting on the condition_variable
+  std::atomic<int> list_of_pending_changes_;
+  // wait until an update occurs
+  std::condition_variable wait_for_update_;
+  // the saving thread ends if the daemon is shutting down (kill=true)
+  bool kill_saving_thread_;
+  bool dump_enabled_;
+};
+} // namespace polycube::polycubed

--- a/src/polycubed/src/peer_iface.cpp
+++ b/src/polycubed/src/peer_iface.cpp
@@ -33,8 +33,8 @@ int PeerIface::calculate_cube_index(int index) {
 
 enum class Position { AUTO, FIRST, LAST };
 
-void PeerIface::add_cube(TransparentCube *cube, const std::string &position,
-                         const std::string &other) {
+int PeerIface::add_cube(TransparentCube *cube, const std::string &position,
+                        const std::string &other) {
   std::lock_guard<std::mutex> guard(mutex_);
   int index = 0;
   int other_index;
@@ -92,6 +92,7 @@ void PeerIface::add_cube(TransparentCube *cube, const std::string &position,
 
   cubes_.insert(cubes_.begin() + calculate_cube_index(index), cube);
   update_indexes();
+  return index;
 }
 
 void PeerIface::remove_cube(const std::string &cube_name) {

--- a/src/polycubed/src/peer_iface.h
+++ b/src/polycubed/src/peer_iface.h
@@ -48,8 +48,8 @@ class PeerIface {
   virtual void set_parameter(const std::string &param_name,
                              const std::string &value) = 0;
 
-  void add_cube(TransparentCube *cube, const std::string &position,
-                const std::string &other);
+  int add_cube(TransparentCube *cube, const std::string &position,
+               const std::string &other);
   void remove_cube(const std::string &type);
   std::vector<std::string> get_cubes_names() const;
 

--- a/src/polycubed/src/polycubed.cpp
+++ b/src/polycubed/src/polycubed.cpp
@@ -37,6 +37,7 @@
 #include <spdlog/sinks/stdout_sinks.h>
 
 #include "polycubed_core.h"
+#include "cubes_dump.h"
 
 #define REQUIRED_POLYCUBED_KERNEL ("4.14.0")
 
@@ -54,6 +55,7 @@ std::shared_ptr<spdlog::logger> logger;
 // create core instance
 PolycubedCore *core;
 RestServer *restserver;
+CubesDump *cubesdump;
 int netlink_notification_id = -1;
 
 void shutdown() {
@@ -68,6 +70,10 @@ void shutdown() {
     logger->debug("rest server shutdown");
     delete core;
     delete restserver;
+  }
+
+  if (cubesdump) {
+    delete cubesdump;
   }
 
   if (netlink_notification_id != -1) {
@@ -277,6 +283,24 @@ int main(int argc, char *argv[]) {
 
   // register services that are shipped with polycube
   load_services(*core);
+
+  // create a cubes dump instance if needed
+  //if (!config.getCubesNoDump()) {
+  if (config.getCubesDumpEnabled()) {
+    cubesdump = new CubesDump();
+    core->set_cubes_dump(cubesdump);
+  }
+
+  // In case the user does not want to initialize the Polycube virtual network,
+  // let's load the last topology that was present when the daemon was shut down.
+  if (!config.getCubesDumpCleanInit()) {
+    restserver->load_last_topology();
+  }
+
+  if (config.getCubesDumpEnabled()) {
+    // start to saving topology only after it has been loaded
+    cubesdump->Enable();
+  }
 
   // pause the execution of current thread until ctrl+c
   pause();

--- a/src/polycubed/src/polycubed_core.h
+++ b/src/polycubed/src/polycubed_core.h
@@ -24,6 +24,7 @@
 #include <unordered_map>
 
 #include "base_model.h"
+#include "cubes_dump.h"
 #include "polycube/services/guid.h"
 #include "polycube/services/json.hpp"
 #include "service_controller.h"
@@ -98,6 +99,10 @@ class PolycubedCore {
 
   void set_rest_server(RestServer *rest_server);
   RestServer *get_rest_server();
+
+  void set_cubes_dump(CubesDump *cubes_dump);
+  CubesDump *get_cubes_dump();
+
   BaseModel *base_model();
 
  private:
@@ -117,6 +122,8 @@ class PolycubedCore {
   std::shared_ptr<spdlog::logger> logger;
   RestServer *rest_server_;
   BaseModel *base_model_;
+  // This manages the cubes configuration in memory and the dump to file
+  CubesDump *cubes_dump_;
 };
 
 }  // namespace polycubed

--- a/src/polycubed/src/rest_server.h
+++ b/src/polycubed/src/rest_server.h
@@ -50,7 +50,7 @@ class RestServer {
 
   std::shared_ptr<Pistache::Rest::Router> get_router();
 
-  const std::string base = "/polycube/v1/";
+  static const std::string base;
 
   void init(size_t thr = 1, const std::string &server_cert = "",
             const std::string &server_key = "",
@@ -60,6 +60,7 @@ class RestServer {
 
   void start();
   void shutdown();
+  void load_last_topology();
 
  private:
   void setup_routes();
@@ -85,8 +86,8 @@ class RestServer {
   void get_cube(const Pistache::Rest::Request &request,
                 Pistache::Http::ResponseWriter response);
 
-    void post_cubes(const Pistache::Rest::Request &request,
-                       Pistache::Http::ResponseWriter response);
+  void post_cubes(const Pistache::Rest::Request &request,
+                     Pistache::Http::ResponseWriter response);
 
   void cubes_help(const Pistache::Rest::Request &request,
                   Pistache::Http::ResponseWriter response);
@@ -129,6 +130,8 @@ class RestServer {
 
   void get_version(const Pistache::Rest::Request &request,
                    Pistache::Http::ResponseWriter response);
+
+  void create_cubes(json &cubes);
 
   void logRequest(const Pistache::Rest::Request &request);
   void logJson(json j);

--- a/src/polycubed/src/server/Resources/Body/ListKey.h
+++ b/src/polycubed/src/server/Resources/Body/ListKey.h
@@ -65,6 +65,8 @@ class ListKey {
 };
 
 struct ListKeyValue {
+  const std::string list_element;
+  const std::string original_key;
   const std::string &name;
   const ListType type;
   const std::string value;

--- a/src/polycubed/src/server/Resources/Endpoint/LeafResource.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/LeafResource.cpp
@@ -26,6 +26,8 @@
 #include "../../Server/ResponseGenerator.h"
 #include "Service.h"
 #include "rest_server.h"
+#include "../../config.h"
+#include "cubes_dump.h"
 
 namespace polycube::polycubed::Rest::Resources::Endpoint {
 LeafResource::LeafResource(
@@ -113,6 +115,13 @@ void LeafResource::CreateReplaceUpdate(const Pistache::Rest::Request &request,
     auto op = Operation::kUpdate;
     auto resp = WriteValue(cube_name, jbody, keys, op);
     errors.push_back(resp);
+    // check if the operation completed successfully and in case update the configuration
+    if (isOperationSuccessful(resp.error_tag)) {
+      if (auto d = core_->get_cubes_dump()) {
+        d->UpdateCubesConfig(request.resource(), jbody, keys, op,
+                ResourceType::LeafResource);
+      }
+    }
   }
   Server::ResponseGenerator::Generate(std::move(errors), std::move(response));
 }

--- a/src/polycubed/src/server/Resources/Endpoint/ListResource.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/ListResource.cpp
@@ -27,6 +27,7 @@
 #include "Service.h"
 #include "rest_server.h"
 #include "utils/utils.h"
+#include "cubes_dump.h"
 
 #include "../Data/Lib/ListResource.h"
 
@@ -117,7 +118,7 @@ void ListResource::Keys(const Pistache::Rest::Request &request,
     std::string param_ = request.param(':' + k.Name()).as<std::string>();
     std::string param = utils::decode_url(param_);
     parsed.push_back(
-        {k.Name(), k.Type(), param});
+        {this->name_, k.OriginalName(), k.Name(), k.Type(), param});
   }
   dynamic_cast<const ParentResource *const>(parent_)->Keys(request, parsed);
 }
@@ -129,7 +130,7 @@ void ListResource::GetListKeys(const Pistache::Rest::Request &request,
       std::string param_ = request.param(':' + k.Name()).as<std::string>();
       std::string param = utils::decode_url(param_);
       parsed.push_back(
-          {k.Name(), k.Type(), param});
+          {this->name_, k.OriginalName(), k.Name(), k.Type(), param});
     }
   }
 }
@@ -179,6 +180,13 @@ void ListResource::CreateReplaceUpdateWhole(
       errors.push_back({ErrorTag::kCreated, nullptr});
     } else {
       errors.push_back(resp);
+    }
+    // check if the operation completed successfully and in case update the configuration
+    if (isOperationSuccessful(resp.error_tag)) {
+      if (auto d = core_->get_cubes_dump()) {
+        d->UpdateCubesConfig(request.resource(), jbody, keys, op,
+                ResourceType::ListResource);
+      }
     }
   }
   Server::ResponseGenerator::Generate(std::move(errors), std::move(response));
@@ -230,11 +238,16 @@ void ListResource::del_multiple(const Request &request,
     std::copy(std::begin(rerrors), std::end(rerrors),
               std::back_inserter(errors));
   }
+  // check if the operation completed successfully and in case update the configuration
   if (errors.empty()) {
     const auto &cube_name = Service::Cube(request);
     ListKeyValues keys{};
     dynamic_cast<const ParentResource *const>(parent_)->Keys(request, keys);
     errors.push_back(DeleteWhole(cube_name, keys));
+    if (auto d = core_->get_cubes_dump()) {
+      d->UpdateCubesConfig(request.resource(), nullptr, keys,
+              Operation::kDelete, ResourceType::ListResource);
+    }
   }
   Server::ResponseGenerator::Generate(std::move(errors), std::move(response));
 }

--- a/src/polycubed/src/server/Resources/Endpoint/ParentResource.h
+++ b/src/polycubed/src/server/Resources/Endpoint/ParentResource.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <spdlog/logger.h>
 
 #include "../Body/ParentResource.h"
 #include "Resource.h"
@@ -95,5 +96,7 @@ class ParentResource : public Resource, public virtual Body::ParentResource {
   virtual void del(const Request &request, ResponseWriter response);
 
   void options(const Request &request, ResponseWriter response);
+
+  std::shared_ptr<spdlog::logger> logger;
 };
 }  // namespace polycube::polycubed::Rest::Resources::Endpoint

--- a/src/polycubed/src/server/Resources/Endpoint/Resource.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/Resource.cpp
@@ -16,6 +16,9 @@
 #include "Resource.h"
 
 #include <string>
+#include <fstream>
+#include <rest_server.h>
+#include "../../config.h"
 
 namespace polycube::polycubed::Rest::Resources::Endpoint {
 
@@ -33,4 +36,11 @@ Operation Resource::OperationType(bool update, bool initialization) {
     }
   }
 }
+
+bool Resource::isOperationSuccessful(ErrorTag errorTag) {
+  return errorTag == ErrorTag::kOk ||
+         errorTag == ErrorTag::kCreated ||
+         errorTag == ErrorTag::kNoContent;
+}
+
 }  // namespace polycube::polycubed::Rest::Resources::Endpoint

--- a/src/polycubed/src/server/Resources/Endpoint/Resource.h
+++ b/src/polycubed/src/server/Resources/Endpoint/Resource.h
@@ -26,10 +26,12 @@
 
 namespace polycube::polycubed::Rest::Resources::Endpoint {
 
-enum class Operation { kCreate, kReplace, kUpdate };
+enum class Operation { kCreate, kReplace, kUpdate, kDelete };
+enum class ResourceType {Service, ParentResource, ListResource, LeafResource};
 
 class Resource {
  public:
+
   explicit Resource(const std::string &rest_endpoint);
 
   virtual ~Resource() = default;
@@ -55,6 +57,8 @@ class Resource {
                                    bool update, bool initialization) = 0;
 
   static Operation OperationType(bool update, bool initialization);
+
+  static bool isOperationSuccessful(ErrorTag errorTag);
 
   virtual void Keys(const Pistache::Rest::Request &request,
                     ListKeyValues &parsed) const = 0;

--- a/src/polycubed/src/server/Resources/Endpoint/Service.h
+++ b/src/polycubed/src/server/Resources/Endpoint/Service.h
@@ -56,7 +56,8 @@ class Service : public ParentResource, public Body::Service {
 
   virtual Response ReadHelp() = 0;
 
-  std::vector<Response> CreateReplaceUpdate(const std::string &name, nlohmann::json &body,
+  std::vector<Response> CreateReplaceUpdate(const std::string &name,
+                                            nlohmann::json &body,
                                             bool update, bool initialization);
 
  private:


### PR DESCRIPTION
This feature allows to load a topology from file at startup, either from the default folder or from a user selected file (ex. polycubed --cubes-dump ~/Desktop/cubes.yaml), keeping the whole configuration in memory.
After each modification in any of the topology of the cube, the configuration in memory is updated and another thread saves it to file updating it too.
It is possible to start the daemon with an empty topology by using the flag --cubes-init: if the file contains a topology, at the first update it is overwritten.
It is possible to start the daemon without the dumping to file functionality by using the flag --cubes-nodump.