### PR TITLE
fix align interfaces logic

### DIFF
--- a/src/polycubed/src/port.h
+++ b/src/polycubed/src/port.h
@@ -122,7 +122,6 @@ class Port : public polycube::service::PortIface, public PeerIface {
   uint16_t calculate_index() const;
 
   std::unordered_map<std::string, ParameterEventCallback> subscription_list;
-  std::mutex subscription_list_mutex;
 };
 
 }  // namespace polycubed

--- a/src/polycubed/src/utils/netlink.h
+++ b/src/polycubed/src/utils/netlink.h
@@ -110,8 +110,10 @@ class Netlink {
 
   void notify(const Event &event, int ifindex, const std::string &ifname) {
     std::map<int, std::function<void(int, const std::string &)>> ob_copy;
-    std::lock_guard<std::mutex> lock(notify_mutex);
-    ob_copy.insert(observers_[event].begin(), observers_[event].end());
+    {
+      std::lock_guard<std::mutex> lock(notify_mutex);
+      ob_copy.insert(observers_[event].begin(), observers_[event].end());
+    }
 
     for (const auto &it : ob_copy) {
       auto obs = it.second;


### PR DESCRIPTION
Some fixes for the align interfaces:
- use port_mutex instead of a new one
- do not call a function to update the port ip in router
- call callbacks in netlink without helding a lock

Fixes: 48bf03919f91 ("Merge pull request #158 from francescomessina/align_ifaces")
