### PR TITLE
fix pr/save_load_topology bug

### DIFF
--- a/src/polycubed/src/config.cpp
+++ b/src/polycubed/src/config.cpp
@@ -508,6 +508,7 @@ bool Config::load(int argc, char *argv[]) {
   }
 
   load_from_file(configfile);
+  cubes_dump_file_flag = false;
   load_from_cli(argc, argv);
   check();
 

--- a/src/polycubed/src/polycubed.cpp
+++ b/src/polycubed/src/polycubed.cpp
@@ -289,15 +289,13 @@ int main(int argc, char *argv[]) {
   if (config.getCubesDumpEnabled()) {
     cubesdump = new CubesDump();
     core->set_cubes_dump(cubesdump);
-  }
 
-  // In case the user does not want to initialize the Polycube virtual network,
-  // let's load the last topology that was present when the daemon was shut down.
-  if (!config.getCubesDumpCleanInit()) {
-    restserver->load_last_topology();
-  }
+    // In case the user does not want to initialize the Polycube virtual network,
+    // let's load the last topology that was present when the daemon was shut down.
+    if (!config.getCubesDumpCleanInit()) {
+      restserver->load_last_topology();
+    }
 
-  if (config.getCubesDumpEnabled()) {
     // start to saving topology only after it has been loaded
     cubesdump->Enable();
   }


### PR DESCRIPTION
Set to false the Config::cubes_dump_file_flag before cli arguments parsing
and load topology only if requested.