### PR TITLE
fix polycubed.conf default configuration and cubes dump bug

### DIFF
--- a/src/polycubed/src/config.cpp
+++ b/src/polycubed/src/config.cpp
@@ -299,8 +299,9 @@ void Config::create_configuration_file(const std::string &path) {
   file << "addr: " << server_ip << std::endl;
   file << "# file to save polycube logs" << std::endl;
   file << "logfile: " << logfile << std::endl;
-  file << "# file to save last topology" << std::endl;
-  file << "cubes-dump-file: " << cubes_dump_file << std::endl;
+  // uncomment when cubes dump is enabled as default behavior
+  //file << "# file to save last topology" << std::endl;
+  //file << "cubes-dump-file: " << cubes_dump_file << std::endl;
   file << "# Security related:" << std::endl;
   file << "# server certificate " << std::endl;
   file << "#cert: path_to_certificate_file" << std::endl;
@@ -508,7 +509,6 @@ bool Config::load(int argc, char *argv[]) {
   }
 
   load_from_file(configfile);
-  cubes_dump_file_flag = false;
   load_from_cli(argc, argv);
   check();
 

--- a/src/polycubed/src/server/Resources/Endpoint/LeafResource.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/LeafResource.cpp
@@ -116,11 +116,10 @@ void LeafResource::CreateReplaceUpdate(const Pistache::Rest::Request &request,
     auto resp = WriteValue(cube_name, jbody, keys, op);
     errors.push_back(resp);
     // check if the operation completed successfully and in case update the configuration
-    if (isOperationSuccessful(resp.error_tag)) {
-      if (auto d = core_->get_cubes_dump()) {
-        d->UpdateCubesConfig(request.resource(), jbody, keys, op,
-                ResourceType::LeafResource);
-      }
+    if (isOperationSuccessful(resp.error_tag) &&
+        configuration::config.getCubesDumpEnabled()) {
+      core_->get_cubes_dump()->UpdateCubesConfig(request.resource(), jbody,
+              keys, op, ResourceType::LeafResource);
     }
   }
   Server::ResponseGenerator::Generate(std::move(errors), std::move(response));

--- a/src/polycubed/src/server/Resources/Endpoint/ListResource.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/ListResource.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+#include "../../config.h"
 #include "../../Server/ResponseGenerator.h"
 #include "../Body/JsonNodeField.h"
 #include "../Body/ListKey.h"
@@ -182,11 +183,10 @@ void ListResource::CreateReplaceUpdateWhole(
       errors.push_back(resp);
     }
     // check if the operation completed successfully and in case update the configuration
-    if (isOperationSuccessful(resp.error_tag)) {
-      if (auto d = core_->get_cubes_dump()) {
-        d->UpdateCubesConfig(request.resource(), jbody, keys, op,
-                ResourceType::ListResource);
-      }
+    if (isOperationSuccessful(resp.error_tag) &&
+        configuration::config.getCubesDumpEnabled()) {
+      core_->get_cubes_dump()->UpdateCubesConfig(request.resource(), jbody,
+              keys, op, ResourceType::ListResource);
     }
   }
   Server::ResponseGenerator::Generate(std::move(errors), std::move(response));
@@ -244,8 +244,8 @@ void ListResource::del_multiple(const Request &request,
     ListKeyValues keys{};
     dynamic_cast<const ParentResource *const>(parent_)->Keys(request, keys);
     errors.push_back(DeleteWhole(cube_name, keys));
-    if (auto d = core_->get_cubes_dump()) {
-      d->UpdateCubesConfig(request.resource(), nullptr, keys,
+    if (configuration::config.getCubesDumpEnabled()) {
+      core_->get_cubes_dump()->UpdateCubesConfig(request.resource(), nullptr, keys,
               Operation::kDelete, ResourceType::ListResource);
     }
   }

--- a/src/polycubed/src/server/Resources/Endpoint/ParentResource.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/ParentResource.cpp
@@ -130,15 +130,14 @@ void ParentResource::CreateReplaceUpdate(
       errors.push_back(resp);
     }
     // check if the operation completed successfully and in case update the configuration
-    if (isOperationSuccessful(resp.error_tag)) {
-      if (auto d = core_->get_cubes_dump()) {
-        if (rpc_action_) {
-          logger->warn("An action has been received: it is not supported "
-                       "by polycube stateful functionalities yet.");
-        } else {
-          d->UpdateCubesConfig(request.resource(), jbody, keys, op,
-                  ResourceType::ParentResource);
-        }
+    if (isOperationSuccessful(resp.error_tag) &&
+        configuration::config.getCubesDumpEnabled()) {
+      if (rpc_action_) {
+        logger->warn("An action has been received: it is not supported "
+                     "by polycube stateful functionalities yet.");
+      } else {
+        core_->get_cubes_dump()->UpdateCubesConfig(request.resource(), jbody,
+                keys, op, ResourceType::ParentResource);
       }
     }
   }
@@ -225,8 +224,8 @@ void ParentResource::del(const Request &request, ResponseWriter response) {
         std::vector<Response>{{ErrorTag::kNoContent, nullptr}},
         std::move(response));
     errors.push_back({ErrorTag::kCreated, nullptr});
-    if (auto d = core_->get_cubes_dump()) {
-      d->UpdateCubesConfig(request.resource(), nullptr, keys,
+    if (configuration::config.getCubesDumpEnabled()) {
+      core_->get_cubes_dump()->UpdateCubesConfig(request.resource(), nullptr, keys,
               Operation::kDelete, ResourceType::ParentResource);
     }
   } else {

--- a/src/polycubed/src/server/Resources/Endpoint/Service.cpp
+++ b/src/polycubed/src/server/Resources/Endpoint/Service.cpp
@@ -105,8 +105,8 @@ Service::CreateReplaceUpdate(const std::string &name, nlohmann::json &body,
       if (!update) {
         cube_names_.AddValue(name);
       }
-      if (auto d = core_->get_cubes_dump()) {
-        d->UpdateCubesConfig(RestServer::base + this->name_ + "/" + name + "/",
+      if (configuration::config.getCubesDumpEnabled()) {
+        core_->get_cubes_dump()->UpdateCubesConfig(RestServer::base + this->name_ + "/" + name + "/",
                 body, k, op, ResourceType::Service);
       }
     }
@@ -218,9 +218,10 @@ void Service::del(const Pistache::Rest::Request &request,
   auto res = DeleteValue(name, k);
   Server::ResponseGenerator::Generate(std::vector<Response>{res},
                                       std::move(response));
-  if (auto d = core_->get_cubes_dump()) {
-    d->UpdateCubesConfig(RestServer::base + this->name_ + "/" + name + "/",
-            nullptr, k, Operation::kDelete, ResourceType::Service);
+  if (configuration::config.getCubesDumpEnabled()) {
+    core_->get_cubes_dump()->UpdateCubesConfig(
+            RestServer::base + this->name_ + "/" + name + "/",nullptr, k,
+            Operation::kDelete, ResourceType::Service);
   }
 }
 


### PR DESCRIPTION
Commented default cubes-dump-file configuration to avoid affecting
parameters validation and removed useless variable assignment.
Check if the dump is enabled with the variable set in config.cpp
instead of checking if CubesDump instance is created or not.