### PR TITLE
Fixing misleading message when polycubed is not executed as root

### DIFF
--- a/src/polycubed/src/polycubed.cpp
+++ b/src/polycubed/src/polycubed.cpp
@@ -173,6 +173,12 @@ int main(int argc, char *argv[]) {
       exit(EXIT_SUCCESS);
     }
   } catch (const std::exception &e) {
+
+    // The problem of the error in loading the config file may be due to
+    // polycubed executed as normal user
+    if (getuid())
+      logger->critical("polycubed should be executed with root privileges");
+
     logger->critical("Error loading config: {}", e.what());
     exit(EXIT_FAILURE);
   }
@@ -182,7 +188,7 @@ int main(int argc, char *argv[]) {
   logger->set_level(config.getLogLevel());
 
   if (getuid()) {
-    logger->critical("please run polycubed as root");
+    logger->critical("polycubed should be executed with root privileges");
     exit(EXIT_FAILURE);
   }
 


### PR DESCRIPTION
When running polycubed as normal user, the printed error is misleading, as it appears that polycubed cannot open the log file.

Signed-off-by: Fulvio Risso <fulvio.risso@polito.it>