### PR TITLE
polycubed_core: initializes the cubes_dump_ variable to null

### DIFF
--- a/src/polycubed/src/polycubed_core.cpp
+++ b/src/polycubed/src/polycubed_core.cpp
@@ -35,7 +35,8 @@ namespace polycube {
 namespace polycubed {
 
 PolycubedCore::PolycubedCore(BaseModel *base_model)
-    : base_model_(base_model), logger(spdlog::get("polycubed")) {}
+    : base_model_(base_model), logger(spdlog::get("polycubed")),
+      cubes_dump_(nullptr) {}
 
 PolycubedCore::~PolycubedCore() {
   servicectrls_map_.clear();


### PR DESCRIPTION
If cubes_dump is not initialized properly, it may happen that a wrong memory area is accessed while this is dereference below.
This causes random failures like deadlocks, segmentation faults or even a "invalid argument" message.