### PR TITLE
libpolycube: rename functions in the utils library

### DIFF
--- a/src/libs/polycube/include/polycube/services/utils.h
+++ b/src/libs/polycube/include/polycube/services/utils.h
@@ -28,13 +28,15 @@ namespace polycube {
 namespace service {
 namespace utils {
 
-/* ip (a.b.c.d) to string and viceversa in big endian */
-uint32_t ip_string_to_be_uint(const std::string &ip);
-std::string be_uint_to_ip_string(uint32_t ip);
+/* ip (a.b.c.d) to string and viceversa
+ * Number is in network byte order (nbo), i.e., big endian */
+uint32_t ip_string_to_nbo_uint(const std::string &ip);
+std::string nbo_uint_to_ip_string(uint32_t ip);
 
-/* mac (aa:bb:cc:dd:ee:ff) to string and vicersa in big endian */
-uint64_t mac_string_to_be_uint(const std::string &mac);
-std::string be_uint_to_mac_string(uint64_t mac);
+/* mac (aa:bb:cc:dd:ee:ff) to string and vicersa
+ * Number is in network byte order (nbo), i.e., big endian */
+uint64_t mac_string_to_nbo_uint(const std::string &mac);
+std::string nbo_uint_to_mac_string(uint64_t mac);
 
 /* transforms an ipv4 dotted representation into a hexadecimal big endian */
 /* deprecated */

--- a/src/libs/polycube/src/utils.cpp
+++ b/src/libs/polycube/src/utils.cpp
@@ -40,7 +40,7 @@ namespace service {
 namespace utils {
 
 // new set of functions
-uint32_t ip_string_to_be_uint(const std::string &ip) {
+uint32_t ip_string_to_nbo_uint(const std::string &ip) {
   unsigned char a[4];
   int last = -1;
   int rc = std::sscanf(ip.c_str(), "%hhu.%hhu.%hhu.%hhu%n", a + 0, a + 1, a + 2,
@@ -52,14 +52,14 @@ uint32_t ip_string_to_be_uint(const std::string &ip) {
          uint32_t(a[0]);
 }
 
-std::string be_uint_to_ip_string(uint32_t ip) {
+std::string nbo_uint_to_ip_string(uint32_t ip) {
   struct in_addr ip_addr;
   ip_addr.s_addr = ip;
   return std::string(inet_ntoa(ip_addr));
 }
 
 /* https://stackoverflow.com/a/7326381 */
-uint64_t mac_string_to_be_uint(const std::string &mac) {
+uint64_t mac_string_to_nbo_uint(const std::string &mac) {
   uint8_t a[6];
   int last = -1;
   int rc = sscanf(mac.c_str(), "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx%n", a + 0, a + 1,
@@ -71,7 +71,7 @@ uint64_t mac_string_to_be_uint(const std::string &mac) {
          uint64_t(a[2]) << 16 | uint64_t(a[1]) << 8 | uint64_t(a[0]);
 }
 
-std::string be_uint_to_mac_string(uint64_t mac) {
+std::string nbo_uint_to_mac_string(uint64_t mac) {
   uint8_t a[6];
   for (int i = 0; i < 6; i++) {
     a[i] = (mac >> i * 8) & 0xFF;

--- a/src/polycubed/src/utils/netlink.cpp
+++ b/src/polycubed/src/utils/netlink.cpp
@@ -983,7 +983,7 @@ std::string Netlink::get_iface_mac(const std::string &iface) {
 
   uint64_t mac_;
   memcpy(&mac_, mac, sizeof mac_);
-  return polycube::service::utils::be_uint_to_mac_string(mac_);
+  return polycube::service::utils::nbo_uint_to_mac_string(mac_);
 }
 
 void Netlink::set_iface_cidr(const std::string &iface,

--- a/src/services/pcn-bridge/src/Fdb.cpp
+++ b/src/services/pcn-bridge/src/Fdb.cpp
@@ -58,7 +58,7 @@ std::shared_ptr<FdbEntry> Fdb::getEntry(const uint16_t &vlan,
   auto fwdtable = parent_.get_hash_table<fwd_key, fwd_entry>("fwdtable");
   fwd_key key{
       .vlan = vlan,
-      .mac = polycube::service::utils::mac_string_to_be_uint(mac),
+      .mac = polycube::service::utils::mac_string_to_nbo_uint(mac),
   };
 
   try {
@@ -136,7 +136,7 @@ void Fdb::addEntry(const uint16_t &vlan, const std::string &mac,
 
   fwd_key key{
       .vlan = vlan,
-      .mac = polycube::service::utils::mac_string_to_be_uint(mac),
+      .mac = polycube::service::utils::mac_string_to_nbo_uint(mac),
   };
 
   fwd_entry value{
@@ -181,7 +181,7 @@ void Fdb::delEntry(const uint16_t &vlan, const std::string &mac) {
 
   fwd_key key{
       .vlan = vlan,
-      .mac = polycube::service::utils::mac_string_to_be_uint(mac),
+      .mac = polycube::service::utils::mac_string_to_nbo_uint(mac),
   };
 
   try {

--- a/src/services/pcn-bridge/src/FdbEntry.cpp
+++ b/src/services/pcn-bridge/src/FdbEntry.cpp
@@ -73,7 +73,7 @@ void FdbEntry::setPort(const std::string &value) {
 
   fwd_key key{
       .vlan = vlan_,
-      .mac = polycube::service::utils::mac_string_to_be_uint(mac_),
+      .mac = polycube::service::utils::mac_string_to_nbo_uint(mac_),
   };
 
   struct timespec now_timespec;
@@ -132,7 +132,7 @@ std::shared_ptr<FdbEntry> FdbEntry::constructFromMap(Fdb &parent,
   }
 
   uint16_t vlan = key.vlan;
-  std::string mac = polycube::service::utils::be_uint_to_mac_string(key.mac);
+  std::string mac = polycube::service::utils::nbo_uint_to_mac_string(key.mac);
   uint32_t entry_age = now - timestamp;
   uint32_t port_no = value.port;
 

--- a/src/services/pcn-bridge/src/Stp.cpp
+++ b/src/services/pcn-bridge/src/Stp.cpp
@@ -27,7 +27,7 @@ Stp::Stp(Bridge &parent, const StpJsonObject &conf)
   vlan_ = conf.getVlan();
 
   stp_ = stp_create(parent.get_name().c_str(),
-                    reverseMac(polycube::service::utils::mac_string_to_be_uint(
+                    reverseMac(polycube::service::utils::mac_string_to_nbo_uint(
                         parent.getMac())),
                     sendBPDUproxy, this);
 
@@ -122,7 +122,7 @@ void Stp::decrementCounter() {
 
 void Stp::changeMac(const std::string &mac) {
   stp_set_bridge_id(
-      stp_, reverseMac(polycube::service::utils::mac_string_to_be_uint(mac)));
+      stp_, reverseMac(polycube::service::utils::mac_string_to_nbo_uint(mac)));
 
   stp_set_bridge_priority(stp_, priority_);
 }
@@ -161,7 +161,7 @@ void Stp::sendBPDU(struct ofpbuf *bpdu, int port_no, void *aux) {
   uint8_t *buf = (uint8_t *)ofpbuf_base(bpdu);
 
   uint64_t mac =
-      polycube::service::utils::mac_string_to_be_uint(parent_.getMac());
+      polycube::service::utils::mac_string_to_nbo_uint(parent_.getMac());
 
   memcpy(buf + 6, &mac, ETH_ADDR_LEN);  // set source mac
 

--- a/src/services/pcn-ddosmitigator/src/BlacklistDst.cpp
+++ b/src/services/pcn-ddosmitigator/src/BlacklistDst.cpp
@@ -32,7 +32,7 @@ BlacklistDst::~BlacklistDst() {
       parent_.get_percpuhash_table<uint32_t, uint64_t>("dstblacklist");
   logger()->debug("BlacklistDst Destructor. ip {0} ", ip_);
   try {
-    dstblacklist.remove(utils::ip_string_to_be_uint(ip_));
+    dstblacklist.remove(utils::ip_string_to_nbo_uint(ip_));
   } catch (...) {
   }
 }
@@ -71,7 +71,7 @@ uint64_t BlacklistDst::getDropPkts() {
   try {
     auto dstblacklist =
         parent_.get_percpuhash_table<uint32_t, uint64_t>("dstblacklist");
-    auto values = dstblacklist.get(utils::ip_string_to_be_uint(ip_));
+    auto values = dstblacklist.get(utils::ip_string_to_nbo_uint(ip_));
 
     pkts = std::accumulate(values.begin(), values.end(), pkts);
 

--- a/src/services/pcn-ddosmitigator/src/BlacklistSrc.cpp
+++ b/src/services/pcn-ddosmitigator/src/BlacklistSrc.cpp
@@ -32,7 +32,7 @@ BlacklistSrc::~BlacklistSrc() {
       parent_.get_percpuhash_table<uint32_t, uint64_t>("srcblacklist");
   logger()->debug("BlacklistSrc Destructor. ip {0} ", ip_);
   try {
-    srcblacklist.remove(utils::ip_string_to_be_uint(ip_));
+    srcblacklist.remove(utils::ip_string_to_nbo_uint(ip_));
   } catch (...) {
   }
 }
@@ -70,7 +70,7 @@ uint64_t BlacklistSrc::getDropPkts() {
   try {
     auto srcblacklist =
         parent_.get_percpuhash_table<uint32_t, uint64_t>("srcblacklist");
-    auto values = srcblacklist.get(utils::ip_string_to_be_uint(ip_));
+    auto values = srcblacklist.get(utils::ip_string_to_nbo_uint(ip_));
 
     pkts = std::accumulate(values.begin(), values.end(), pkts);
 

--- a/src/services/pcn-ddosmitigator/src/Ddosmitigator.cpp
+++ b/src/services/pcn-ddosmitigator/src/Ddosmitigator.cpp
@@ -190,7 +190,7 @@ void Ddosmitigator::addBlacklistSrc(const std::string &ip,
 
     auto srcblacklist =
         get_percpuhash_table<uint32_t, uint64_t>("srcblacklist");
-    srcblacklist.set(utils::ip_string_to_be_uint(ip), 0);
+    srcblacklist.set(utils::ip_string_to_nbo_uint(ip), 0);
   } catch (...) {
     throw std::runtime_error("unable to add element to map");
   }
@@ -277,7 +277,7 @@ void Ddosmitigator::addBlacklistDst(const std::string &ip,
 
     auto dstblacklist =
         get_percpuhash_table<uint32_t, uint64_t>("dstblacklist");
-    dstblacklist.set(utils::ip_string_to_be_uint(ip), 0);
+    dstblacklist.set(utils::ip_string_to_nbo_uint(ip), 0);
   } catch (...) {
     throw std::runtime_error("unable to add element to map");
   }

--- a/src/services/pcn-firewall/src/Firewall.cpp
+++ b/src/services/pcn-firewall/src/Firewall.cpp
@@ -238,8 +238,8 @@ std::vector<std::shared_ptr<SessionTable>> Firewall::getSessionTableList() {
     auto key = connection.first;
     auto value = connection.second;
 
-    conf.setSrc(utils::be_uint_to_ip_string(key.srcIp));
-    conf.setDst(utils::be_uint_to_ip_string(key.dstIp));
+    conf.setSrc(utils::nbo_uint_to_ip_string(key.srcIp));
+    conf.setDst(utils::nbo_uint_to_ip_string(key.dstIp));
     conf.setL4proto(ChainRule::protocol_from_int_to_string(key.l4proto));
     conf.setSport(ntohs(key.srcPort));
     conf.setDport(ntohs(key.dstPort));

--- a/src/services/pcn-firewall/src/defines.h
+++ b/src/services/pcn-firewall/src/defines.h
@@ -68,7 +68,7 @@ struct IpAddr {
   uint8_t netmask;
   uint32_t ruleId;
   std::string toString() const {
-    return utils::be_uint_to_ip_string(ip) + "/" + std::to_string(netmask);
+    return utils::nbo_uint_to_ip_string(ip) + "/" + std::to_string(netmask);
   }
   void fromString(std::string ipnetmask) {
     std::string ip_;
@@ -86,7 +86,7 @@ struct IpAddr {
       throw std::runtime_error("Netmask can't be bigger than 32");
 
     ip_ = ipnetmask.substr(0, found);
-    ip = utils::ip_string_to_be_uint(ip_);
+    ip = utils::ip_string_to_nbo_uint(ip_);
     netmask = netmask_;
   }
   bool operator<(const IpAddr &that) const {

--- a/src/services/pcn-firewall/src/modules/IpLookup.cpp
+++ b/src/services/pcn-firewall/src/modules/IpLookup.cpp
@@ -76,7 +76,7 @@ void Firewall::IpLookup::updateTableValue(uint8_t netmask, std::string ip,
   tableName += "Trie";
 
   lpm_k key{
-      .netmask_len = netmask, .ip = utils::ip_string_to_be_uint(ip),
+      .netmask_len = netmask, .ip = utils::ip_string_to_nbo_uint(ip),
   };
 
   auto table = firewall.get_raw_table(tableName, index, getProgramType());

--- a/src/services/pcn-iptables/src/Iptables.cpp
+++ b/src/services/pcn-iptables/src/Iptables.cpp
@@ -541,11 +541,11 @@ std::vector<std::shared_ptr<SessionTable>> Iptables::getSessionTableList() {
     auto value = connection.second;
 
     if (value.ipRev) {
-      conf.setSrc(utils::be_uint_to_ip_string(key.dstIp));
-      conf.setDst(utils::be_uint_to_ip_string(key.srcIp));
+      conf.setSrc(utils::nbo_uint_to_ip_string(key.dstIp));
+      conf.setDst(utils::nbo_uint_to_ip_string(key.srcIp));
     } else {
-      conf.setSrc(utils::be_uint_to_ip_string(key.srcIp));
-      conf.setDst(utils::be_uint_to_ip_string(key.dstIp));
+      conf.setSrc(utils::nbo_uint_to_ip_string(key.srcIp));
+      conf.setDst(utils::nbo_uint_to_ip_string(key.dstIp));
     }
 
     conf.setL4proto(ChainRule::protocolFromIntToString(key.l4proto));

--- a/src/services/pcn-iptables/src/defines.h
+++ b/src/services/pcn-iptables/src/defines.h
@@ -86,7 +86,7 @@ struct IpAddr {
   uint8_t netmask;
   uint32_t rule_id;
   std::string toString() const {
-    return utils::be_uint_to_ip_string(ip) + "/" + std::to_string(netmask);
+    return utils::nbo_uint_to_ip_string(ip) + "/" + std::to_string(netmask);
   }
   void fromString(std::string ipnetmask) {
     std::string ip_;
@@ -104,7 +104,7 @@ struct IpAddr {
       throw std::runtime_error("Netmask can't be bigger than 32");
 
     ip_ = ipnetmask.substr(0, found);
-    ip = utils::ip_string_to_be_uint(ip_);
+    ip = utils::ip_string_to_nbo_uint(ip_);
     netmask = netmask_;
   }
   bool operator<(const IpAddr &that) const {

--- a/src/services/pcn-iptables/src/modules/ChainSelector.cpp
+++ b/src/services/pcn-iptables/src/modules/ChainSelector.cpp
@@ -100,7 +100,7 @@ void Iptables::ChainSelector::updateLocalIps() {
       iptables_.logger()->info("ip: {0} was not present. ++ ADDING",
                                new_ip.first);
       try {
-        uint32_t ip_be = polycube::service::utils::ip_string_to_be_uint(
+        uint32_t ip_be = polycube::service::utils::ip_string_to_nbo_uint(
             removeNetFromIp(new_ip.first));
         auto localip_table =
             iptables_.get_hash_table<uint32_t, int>("localip", getIndex());
@@ -117,7 +117,7 @@ void Iptables::ChainSelector::updateLocalIps() {
       iptables_.logger()->info("ip: {0} is not present. -- REMOVING",
                                (*old_ip).first);
       try {
-        uint32_t ip_be = polycube::service::utils::ip_string_to_be_uint(
+        uint32_t ip_be = polycube::service::utils::ip_string_to_nbo_uint(
             removeNetFromIp((*old_ip).first));
         auto localipTable =
             iptables_.get_hash_table<uint32_t, int>("localip", getIndex());

--- a/src/services/pcn-iptables/src/modules/IpLookup.cpp
+++ b/src/services/pcn-iptables/src/modules/IpLookup.cpp
@@ -97,7 +97,7 @@ void Iptables::IpLookup::updateTableValue(uint8_t netmask, std::string ip,
     table_name += "Output";
 
   lpm_k key{
-      .netmask_len = netmask, .ip = utils::ip_string_to_be_uint(ip),
+      .netmask_len = netmask, .ip = utils::ip_string_to_nbo_uint(ip),
   };
 
   std::lock_guard<std::mutex> guard(program_mutex_);

--- a/src/services/pcn-k8switch/src/K8switch.cpp
+++ b/src/services/pcn-k8switch/src/K8switch.cpp
@@ -473,7 +473,7 @@ std::shared_ptr<FwdTable> K8switch::getFwdTable(const std::string &address) {
     auto fwd_table = get_array_table<pod>("fwd_table");
     auto entry = fwd_table.get(ip_key);
 
-    std::string mac = utils::be_uint_to_ip_string(entry.mac);
+    std::string mac = utils::nbo_uint_to_ip_string(entry.mac);
     std::string port(get_port(entry.port)->name());
     return std::make_shared<FwdTable>(FwdTable(*this, address, mac, port));
   } catch (std::exception &e) {
@@ -499,8 +499,8 @@ std::vector<std::shared_ptr<FwdTable>> K8switch::getFwdTableList() {
 
       // TODO: key is only the index, it should be converted back to the full IP
       // address
-      std::string ip = utils::be_uint_to_ip_string(key);
-      std::string mac = utils::be_uint_to_mac_string(value.mac);
+      std::string ip = utils::nbo_uint_to_ip_string(key);
+      std::string mac = utils::nbo_uint_to_mac_string(value.mac);
       std::string port(get_port(value.port)->name());
 
       fwd_table_entries.push_back(
@@ -524,7 +524,7 @@ void K8switch::addFwdTable(const std::string &address,
   auto port = get_port(conf.getPort());
 
   pod p{
-      .mac = utils::mac_string_to_be_uint(conf.getMac()),
+      .mac = utils::mac_string_to_nbo_uint(conf.getMac()),
       .port = uint16_t(port->index()),
   };
 

--- a/src/services/pcn-k8switch/src/Service.cpp
+++ b/src/services/pcn-k8switch/src/Service.cpp
@@ -268,7 +268,7 @@ void Service::removeServiceFromKernelMap() {
 
   for (uint16_t index = 0; index < backend_size_ * BACKEND_REPLICAS; index++) {
     vip key{
-        .ip = utils::ip_string_to_be_uint(getVip()),
+        .ip = utils::ip_string_to_nbo_uint(getVip()),
         .port = htons(getVport()),
         .proto = htons(Service::convertProtoToNumber(getProto())),
         .index = index,
@@ -285,7 +285,7 @@ void Service::removeServiceFromKernelMap() {
         parent_.get_hash_table<backend, vip>(EBPF_BACKEND_TO_SERVICE_MAP);
     for (auto &bck : service_backends_) {
       backend key{
-          .ip = utils::ip_string_to_be_uint(bck.second.getIp()),
+          .ip = utils::ip_string_to_nbo_uint(bck.second.getIp()),
           .port = htons(bck.second.getPort()),
           .proto = htons(Service::convertProtoToNumber(getProto())),
       };
@@ -314,7 +314,7 @@ void Service::updateKernelServiceMap() {
   uint16_t index = 0;
 
   vip key{
-      .ip = utils::ip_string_to_be_uint(getVip()),
+      .ip = utils::ip_string_to_nbo_uint(getVip()),
       .port = htons(getVport()),
       .proto = htons(Service::convertProtoToNumber(getProto())),
       .index = index,
@@ -324,7 +324,7 @@ void Service::updateKernelServiceMap() {
   // pool.
   // In doesn't indicate a real backend
   backend value{
-      .ip = utils::ip_string_to_be_uint(getVip()),
+      .ip = utils::ip_string_to_nbo_uint(getVip()),
       .port = uint8_t(consistent_array.size()),
       .proto = 0,
   };
@@ -341,14 +341,14 @@ void Service::updateKernelServiceMap() {
     auto &bck = service_backends_.at(key);
 
     vip backend_key{
-        .ip = utils::ip_string_to_be_uint(getVip()),
+        .ip = utils::ip_string_to_nbo_uint(getVip()),
         .port = htons(getVport()),
         .proto = htons(Service::convertProtoToNumber(getProto())),
         .index = index,
     };
 
     backend backend_value{
-        .ip = utils::ip_string_to_be_uint(bck.getIp()),
+        .ip = utils::ip_string_to_nbo_uint(bck.getIp()),
         .port = htons(bck.getPort()),
         .proto = htons(Service::convertProtoToNumber(getProto())),
     };
@@ -540,7 +540,7 @@ std::vector<int> Service::getRandomIntVector(int vect_size) {
 
 void Service::insertAsKubeProxyService() {
   vip key{
-      .ip = utils::ip_string_to_be_uint(getVip()),
+      .ip = utils::ip_string_to_nbo_uint(getVip()),
       .port = htons(getVport()),
       .proto = htons(Service::convertProtoToNumber(getProto())),
       .index = 0,
@@ -549,7 +549,7 @@ void Service::insertAsKubeProxyService() {
   // This is a special value used to indicate that the service is implemented by
   // kube-proxy
   backend value{
-      .ip = utils::ip_string_to_be_uint(getVip()), .port = KUBE_PROXY_FLAG,
+      .ip = utils::ip_string_to_nbo_uint(getVip()), .port = KUBE_PROXY_FLAG,
   };
 
   auto services_map = parent_.get_hash_table<vip, backend>(EBPF_SERVICE_MAP);

--- a/src/services/pcn-loadbalancer-dsr/src/Backend.cpp
+++ b/src/services/pcn-loadbalancer-dsr/src/Backend.cpp
@@ -87,7 +87,7 @@ void Backend::addPool(const uint32_t &id, const BackendPoolJsonObject &conf) {
     logger()->info("mac: {0}", conf.getMac());
 
     config_table.set(0, pools_.size());
-    config_table.set(id, utils::mac_string_to_be_uint(conf.getMac()));
+    config_table.set(id, utils::mac_string_to_nbo_uint(conf.getMac()));
   } catch (std::exception &e) {
     logger()->error("[BackendPool] Error while creating the backend pool {0}",
                     id);

--- a/src/services/pcn-loadbalancer-rp/src/Service.cpp
+++ b/src/services/pcn-loadbalancer-rp/src/Service.cpp
@@ -123,7 +123,7 @@ void Service::removeServiceFromKernelMap() {
 
   for (uint16_t index = 0; index < backend_size_ * BACKEND_REPLICAS; index++) {
     vip service_key{
-        .ip = utils::ip_string_to_be_uint(getVip()),
+        .ip = utils::ip_string_to_nbo_uint(getVip()),
         .port = htons(getVport()),
         .proto = htons(Service::convertProtoToNumber(getProto())),
         .index = index,
@@ -176,7 +176,7 @@ void Service::updateKernelServiceMap(
   uint16_t index = 0;
 
   vip service_key{
-      .ip = utils::ip_string_to_be_uint(getVip()),
+      .ip = utils::ip_string_to_nbo_uint(getVip()),
       .port = htons(getVport()),
       .proto = htons(Service::convertProtoToNumber(getProto())),
       .index = index,
@@ -186,7 +186,7 @@ void Service::updateKernelServiceMap(
   // pool.
   // In doesn't indicate a real backend
   backend service_value{
-      .ip = utils::ip_string_to_be_uint(getVip()),
+      .ip = utils::ip_string_to_nbo_uint(getVip()),
       .port = uint16_t(consistent_array.size()),
       .proto = 0,
   };
@@ -199,14 +199,14 @@ void Service::updateKernelServiceMap(
     auto bck = getBackend(backend_ip);
 
     vip key{
-        .ip = utils::ip_string_to_be_uint(getVip()),
+        .ip = utils::ip_string_to_nbo_uint(getVip()),
         .port = htons(getVport()),
         .proto = htons(Service::convertProtoToNumber(getProto())),
         .index = index,
     };
 
     backend value{
-        .ip = utils::ip_string_to_be_uint(bck->getIp()),
+        .ip = utils::ip_string_to_nbo_uint(bck->getIp()),
         .port = htons(bck->getPort()),
         .proto = htons(Service::convertProtoToNumber(getProto())),
     };

--- a/src/services/pcn-loadbalancer-rp/src/SrcIpRewrite.cpp
+++ b/src/services/pcn-loadbalancer-rp/src/SrcIpRewrite.cpp
@@ -75,12 +75,12 @@ void SrcIpRewrite::update(const SrcIpRewriteJsonObject &conf) {
 
   src_ip_r_key key{
       .netmask_len = uint32_t(std::stoi(old_mask_len)),
-      .network = utils::ip_string_to_be_uint(old_ip_net),
+      .network = utils::ip_string_to_nbo_uint(old_ip_net),
   };
 
   src_ip_r_value value{
       .sense = FROM_BACKEND,
-      .net = utils::ip_string_to_be_uint(new_ip_net),
+      .net = utils::ip_string_to_nbo_uint(new_ip_net),
       .mask = new_mask_dec,
   };
 
@@ -89,12 +89,12 @@ void SrcIpRewrite::update(const SrcIpRewriteJsonObject &conf) {
   // create entry for packets comming from the service
   src_ip_r_key key0{
       .netmask_len = uint32_t(std::stoi(new_mask_len)),
-      .network = utils::ip_string_to_be_uint(new_ip_net),
+      .network = utils::ip_string_to_nbo_uint(new_ip_net),
   };
 
   src_ip_r_value value0{
       .sense = FROM_BACKEND,  // TODO: is this value right?
-      .net = utils::ip_string_to_be_uint(old_ip_net),
+      .net = utils::ip_string_to_nbo_uint(old_ip_net),
       .mask = old_mask_dec,
   };
 

--- a/src/services/pcn-nat/src/IpAddr.h
+++ b/src/services/pcn-nat/src/IpAddr.h
@@ -25,7 +25,7 @@ struct IpAddr {
   uint32_t ip;
   uint8_t netmask;
   std::string toString() const {
-    return utils::be_uint_to_ip_string(ip) + "/" + std::to_string(netmask);
+    return utils::nbo_uint_to_ip_string(ip) + "/" + std::to_string(netmask);
   }
   void fromString(std::string ipnetmask) {
     std::string ip_;
@@ -43,7 +43,7 @@ struct IpAddr {
       throw std::runtime_error("Netmask can't be bigger than 32");
 
     ip_ = ipnetmask.substr(0, found);
-    ip = utils::ip_string_to_be_uint(ip_);
+    ip = utils::ip_string_to_nbo_uint(ip_);
     netmask = netmask_;
   }
   bool operator<(const IpAddr &that) const {

--- a/src/services/pcn-nat/src/Nat.cpp
+++ b/src/services/pcn-nat/src/Nat.cpp
@@ -37,7 +37,7 @@ Nat::Nat(const std::string name, const NatJsonObject &conf)
     logger()->debug("parent IP has been updated to {}", value);
     external_ip_ = value;
     if (rule_->getMasquerade()->getEnabled()) {
-      rule_->getMasquerade()->inject(utils::ip_string_to_be_uint(external_ip_));
+      rule_->getMasquerade()->inject(utils::ip_string_to_nbo_uint(external_ip_));
     }
   };
   subscribe_parent_parameter("ip", cb);
@@ -160,8 +160,8 @@ std::shared_ptr<NattingTable> Nat::getNattingTable(
   try {
     auto table = get_hash_table<st_k, st_v>("egress_session_table");
     st_k map_key{
-        .src_ip = utils::ip_string_to_be_uint(internalSrc),
-        .dst_ip = utils::ip_string_to_be_uint(internalDst),
+        .src_ip = utils::ip_string_to_nbo_uint(internalSrc),
+        .dst_ip = utils::ip_string_to_nbo_uint(internalDst),
         .src_port = htons(internalSport),
         .dst_port = htons(internalDport),
         .proto = uint8_t(std::stol(proto)),
@@ -169,7 +169,7 @@ std::shared_ptr<NattingTable> Nat::getNattingTable(
 
     st_v value = table.get(map_key);
 
-    std::string newIp = utils::be_uint_to_ip_string(value.new_ip);
+    std::string newIp = utils::nbo_uint_to_ip_string(value.new_ip);
     uint16_t newPort = value.new_port;
     uint8_t originatingRule = value.originating_rule_type;
     ;
@@ -192,10 +192,10 @@ std::vector<std::shared_ptr<NattingTable>> Nat::getNattingTableList() {
       auto value = pair.second;
 
       auto entry = std::make_shared<NattingTable>(
-          *this, utils::be_uint_to_ip_string(key.src_ip),
-          utils::be_uint_to_ip_string(key.dst_ip), ntohs(key.src_port),
+          *this, utils::nbo_uint_to_ip_string(key.src_ip),
+          utils::nbo_uint_to_ip_string(key.dst_ip), ntohs(key.src_port),
           ntohs(key.dst_port), key.proto,
-          utils::be_uint_to_ip_string(value.new_ip), ntohs(value.new_port),
+          utils::nbo_uint_to_ip_string(value.new_ip), ntohs(value.new_port),
           value.originating_rule_type);
 
       entries.push_back(entry);

--- a/src/services/pcn-nat/src/RuleMasquerade.cpp
+++ b/src/services/pcn-nat/src/RuleMasquerade.cpp
@@ -83,7 +83,7 @@ RuleMasqueradeEnableOutputJsonObject RuleMasquerade::enable() {
   uint32_t ip = 0;
 
   try {
-    ip = utils::ip_string_to_be_uint(
+    ip = utils::ip_string_to_nbo_uint(
                        parent_.getParent().getExternalIpString());
   } catch(...) {
     output.setResult(false);

--- a/src/services/pcn-pbforwarder/src/Rules.cpp
+++ b/src/services/pcn-pbforwarder/src/Rules.cpp
@@ -327,11 +327,11 @@ rule Rules::to_rule() {
   }
 
   rule r{
-      .srcMac = utils::mac_string_to_be_uint(srcMac),
-      .dstMac = utils::mac_string_to_be_uint(dstMac),
+      .srcMac = utils::mac_string_to_nbo_uint(srcMac),
+      .dstMac = utils::mac_string_to_nbo_uint(dstMac),
       .vlanid = vlan,
-      .srcIp = utils::ip_string_to_be_uint(srcIp),
-      .dstIp = utils::ip_string_to_be_uint(dstIp),
+      .srcIp = utils::ip_string_to_nbo_uint(srcIp),
+      .dstIp = utils::ip_string_to_nbo_uint(dstIp),
       .lvl4_proto = rulesL4ProtoEnum_to_int(L4Proto),
       .src_port = srcPort,
       .dst_port = dstPort,

--- a/src/services/pcn-router/src/Ports.cpp
+++ b/src/services/pcn-router/src/Ports.cpp
@@ -49,8 +49,8 @@ Ports::Ports(polycube::service::Cube<Ports> &parent,
     // TODO: check that no other router port exists in the same network
     ip_ = conf.getIp();
     split_ip_and_prefix(ip_, ip_address, netmask);
-    ip_uint = ip_string_to_be_uint(ip_address);
-    netmask_uint = ip_string_to_be_uint(netmask);
+    ip_uint = ip_string_to_nbo_uint(ip_address);
+    netmask_uint = ip_string_to_nbo_uint(netmask);
   } else {
     ip_ = "";
     ip_uint = 0;
@@ -66,7 +66,7 @@ Ports::Ports(polycube::service::Cube<Ports> &parent,
       .netmask = netmask_uint,
       .secondary_ip = {},
       .secondary_netmask = {},
-      .mac = mac_string_to_be_uint(mac_),
+      .mac = mac_string_to_nbo_uint(mac_),
   };
 
   uint16_t index = this->index();
@@ -76,8 +76,8 @@ Ports::Ports(polycube::service::Cube<Ports> &parent,
   for (auto &addr : secondary_ips) {
     std::string secondaryIp = addr.getIp();
     split_ip_and_prefix(secondaryIp, ip_address, netmask);
-    ip_uint = ip_string_to_be_uint(ip_address);
-    netmask_uint = ip_string_to_be_uint(netmask);
+    ip_uint = ip_string_to_nbo_uint(ip_address);
+    netmask_uint = ip_string_to_nbo_uint(netmask);
     value.secondary_ip[i] = ip_uint;
     value.secondary_netmask[i] = netmask_uint;
     i++;
@@ -201,8 +201,8 @@ void Ports::doSetIp(const std::string &new_ip) {
 
   try {
     r_port value = router_port.get(index);
-    value.ip = ip_string_to_be_uint(ip_address);
-    value.netmask = ip_string_to_be_uint(netmask);
+    value.ip = ip_string_to_nbo_uint(ip_address);
+    value.netmask = ip_string_to_nbo_uint(netmask);
   } catch (...) {
     logger()->error("Port {0} not found in the data path", this->name());
   }
@@ -336,7 +336,7 @@ void Ports::doSetMac(const std::string &new_mac) {
   auto router_port = parent_.get_hash_table<uint16_t, r_port>("router_port");
 
   r_port map_value = router_port.get(index);
-  map_value.mac = mac_string_to_be_uint(new_mac);
+  map_value.mac = mac_string_to_nbo_uint(new_mac);
   router_port.set(index, map_value);
 
   logger()->debug(
@@ -353,8 +353,8 @@ void Ports::updatePortInDataPath() {
   uint32_t netmask_uint = 0;
 
   split_ip_and_prefix(ip_, ip_address, netmask);
-  ip_uint = ip_string_to_be_uint(ip_address);
-  netmask_uint = ip_string_to_be_uint(netmask);
+  ip_uint = ip_string_to_nbo_uint(ip_address);
+  netmask_uint = ip_string_to_nbo_uint(netmask);
 
   auto router_port = parent_.get_hash_table<uint16_t, r_port>("router_port");
   r_port value{
@@ -362,7 +362,7 @@ void Ports::updatePortInDataPath() {
       .netmask = netmask_uint,
       .secondary_ip = {},
       .secondary_netmask = {},
-      .mac = mac_string_to_be_uint(mac_),
+      .mac = mac_string_to_nbo_uint(mac_),
   };
 
   uint16_t index = this->index();
@@ -370,8 +370,8 @@ void Ports::updatePortInDataPath() {
   for (auto addr : secondary_ips_) {
     std::string secondaryIp = addr.getIp();
     split_ip_and_prefix(secondaryIp, ip_address, netmask);
-    ip_uint = ip_string_to_be_uint(ip_address);
-    netmask_uint = ip_string_to_be_uint(netmask);
+    ip_uint = ip_string_to_nbo_uint(ip_address);
+    netmask_uint = ip_string_to_nbo_uint(netmask);
     value.secondary_ip[i] = ip_uint;
     value.secondary_netmask[i] = netmask_uint;
     i++;

--- a/src/services/pcn-simplebridge/src/Fdb.cpp
+++ b/src/services/pcn-simplebridge/src/Fdb.cpp
@@ -77,7 +77,7 @@ std::shared_ptr<FdbEntry> Fdb::getEntry(const std::string &address) {
   logger()->debug("[FdbEntry] mac: {0}", address);
 
   auto fwdtable = parent_.get_hash_table<uint64_t, fwd_entry>("fwdtable");
-  uint64_t key = utils::mac_string_to_be_uint(address);
+  uint64_t key = utils::mac_string_to_nbo_uint(address);
 
   try {
     auto entry = FdbEntry::constructFromMap(*this, address, fwdtable.get(key));
@@ -104,7 +104,7 @@ std::vector<std::shared_ptr<FdbEntry>> Fdb::getEntryList() {
       auto map_key = pair.first;
       auto map_entry = pair.second;
 
-      std::string mac_address = utils::be_uint_to_mac_string(map_key);
+      std::string mac_address = utils::nbo_uint_to_mac_string(map_key);
       auto entry = FdbEntry::constructFromMap(*this, mac_address, map_entry);
       if (!entry)
         continue;
@@ -143,7 +143,7 @@ void Fdb::addEntry(const std::string &address, const FdbEntryJsonObject &conf) {
   struct timespec now_timespec;
   clock_gettime(CLOCK_MONOTONIC, &now_timespec);
 
-  uint64_t key = utils::mac_string_to_be_uint(address);
+  uint64_t key = utils::mac_string_to_nbo_uint(address);
   fwd_entry value{
       .timestamp = (uint32_t)now_timespec.tv_sec, .port = port_index,
   };
@@ -182,7 +182,7 @@ void Fdb::delEntry(const std::string &address) {
     throw std::runtime_error("Filtering database entry not found");
   }
 
-  uint64_t key = utils::mac_string_to_be_uint(address);
+  uint64_t key = utils::mac_string_to_nbo_uint(address);
 
   try {
     auto fwdtable = parent_.get_hash_table<uint64_t, fwd_entry>("fwdtable");

--- a/src/services/pcn-simplebridge/src/FdbEntry.cpp
+++ b/src/services/pcn-simplebridge/src/FdbEntry.cpp
@@ -45,7 +45,7 @@ std::shared_ptr<FdbEntry> FdbEntry::constructFromMap(Fdb &parent,
   clock_gettime(CLOCK_MONOTONIC, &now_timespec);
   uint32_t now = now_timespec.tv_sec;
 
-  uint64_t key = utils::mac_string_to_be_uint(address);
+  uint64_t key = utils::mac_string_to_nbo_uint(address);
   uint32_t timestamp = value.timestamp;
 
   //Here I'm going to check if the entry in the filtering database is too old.\
@@ -82,7 +82,7 @@ void FdbEntry::setPort(const std::string &value) {
     throw std::runtime_error("Port " + value + " doesn't exist");
   }
 
-  uint64_t map_key = utils::mac_string_to_be_uint(address_);
+  uint64_t map_key = utils::mac_string_to_nbo_uint(address_);
   fwd_entry map_value{
       .timestamp = 0, .port = port_index,
   };

--- a/src/services/pcn-simplebridge/src/Ports.cpp
+++ b/src/services/pcn-simplebridge/src/Ports.cpp
@@ -34,7 +34,7 @@ Ports::~Ports() {
       auto map_entry = pair.second;
       if (map_entry.port == index()) {
         fwdtable.remove(map_key);
-        std::string mac_address = utils::be_uint_to_mac_string(map_key);
+        std::string mac_address = utils::nbo_uint_to_mac_string(map_key);
         logger()->debug("Removing entry {0} associated to port {1}",
                         mac_address, name());
       }


### PR DESCRIPTION
-ip_string_to_be_uint => ip_string_to_nbo_uint
-be_uint_to_ip_string => nbo_uint_to_ip_string

-mac_string_to_be_uint => mac_string_to_nbo_uint
-be_uint_to_mac_string => nbo_uint_to_mac_string

Where "nbo" means network byte order