### PR TITLE
Print cleanup

### DIFF
--- a/src/polycubectl/help.go
+++ b/src/polycubectl/help.go
@@ -449,7 +449,7 @@ func printHelp(cliArgs *cliargs.CLIArgs, jsonParsed *gabs2.Container) {
 	if cliArgs.Command == cliargs.AddCommand || cliArgs.Command == cliargs.DelCommand {
 		Buffer += fmt.Sprintf("\nExample: \n %s", example)
 	}
-	Buffer += "\n"
+	Buffer += "\n\n"
 }
 
 func getCubesList() map[string][]string {

--- a/src/services/pcn-bridge/src/Fdb.cpp
+++ b/src/services/pcn-bridge/src/Fdb.cpp
@@ -18,7 +18,7 @@
 #include "Bridge.h"
 
 Fdb::Fdb(Bridge &parent, const FdbJsonObject &conf) : FdbBase(parent) {
-  logger()->info("Creating Fdb instance");
+  logger()->debug("[Fdb] Creating instance");
 
   agingTime_ = conf.getAgingTime();
 
@@ -28,7 +28,7 @@ Fdb::Fdb(Bridge &parent, const FdbJsonObject &conf) : FdbBase(parent) {
 }
 
 Fdb::~Fdb() {
-  logger()->info("Destroying Fdb instance");
+  logger()->debug("[Fdb] Destroying instance");
 }
 
 uint32_t Fdb::getAgingTime() {

--- a/src/services/pcn-iptables/datamodel/iptables.yang
+++ b/src/services/pcn-iptables/datamodel/iptables.yang
@@ -11,6 +11,12 @@ module iptables {
 
   uses "polycube-standard-base:standard-base-yang-module";
 
+  polycube-base:service-description "Iptables-compatible Service";
+  polycube-base:service-version "2.0";
+  polycube-base:service-name "iptables";
+  polycube-base:service-min-kernel-version "4.14.0";
+
+
   typedef action {
     type enumeration {
       enum DROP;


### PR DESCRIPTION
Added a void line at the end when printing the help on screen.
Updated the description of iptables services (it was void before) and adding standard metadata.