### PR TITLE
libpolycube: add a new parameter to the get_parameter in the extiface

### DIFF
--- a/src/polycubed/src/extiface.cpp
+++ b/src/polycubed/src/extiface.cpp
@@ -30,6 +30,7 @@ namespace polycubed {
 
 const std::string PARAMETER_MAC = "MAC";
 const std::string PARAMETER_IP = "IP";
+const std::string PARAMETER_PEER = "PEER";
 
 std::set<std::string> ExtIface::used_ifaces;
 
@@ -372,6 +373,8 @@ std::string ExtIface::get_parameter(const std::string &param_name) {
       // netdev does not have an Ip
       return "";
     }
+  } else if (param_upper == PARAMETER_PEER) {
+    return iface_;
   } else {
     throw std::runtime_error("parameter " + param_upper +
                              " not available in extiface");


### PR DESCRIPTION
When a transparent service is connected to a port it asks for the name of the cube to which it has been connected. 
In the case in which a transparent service is attached to a netdev the name of the netdev is returned.
This PR adds a new parameter to the extiface class, which implements this behavior.