### PR TITLE
keep the pass_to_stack flag in skb 

### DIFF
--- a/src/polycubed/src/transparent_cube_tc.cpp
+++ b/src/polycubed/src/transparent_cube_tc.cpp
@@ -99,7 +99,7 @@ int handle_rx_wrapper(struct CTXTYPE *skb) {
     case RX_DROP:
       return TC_ACT_SHOT;
     case RX_CONTROLLER:
-      skb->cb[0] = CUBE_ID | TYPE << 16;
+      skb->cb[0] = (skb->cb[0] & 0x8000) | CUBE_ID | TYPE << 16;
       return to_controller(skb, md.reason);
     case RX_OK:
 #if NEXT == 0xffff


### PR DESCRIPTION
some caller like pcn_pkt_controller_with_metadata_stack may set this flag. pass_to_stack flag was carried by cb[0] in the first MSB in the last 16 bits (0x8000) and this flag will be used to decide if the packet should be sent to stack for further processing or dropped. 

this fix issue #210 