### PR TITLE
pcn-k8s: Fix pcn-k8s compatibility issue with 1.16

### DIFF
--- a/Documentation/components/k8s/pcn-kubernetes.rst
+++ b/Documentation/components/k8s/pcn-kubernetes.rst
@@ -318,3 +318,8 @@ Developing
 ----------
 
 Refer to :doc:`Developers <developers>`
+
+Compatibility
+----------
+
+Pcn-k8s is compatible with all versions equal or greater than 1.9, although we recommend the latest version of Kubernetes.

--- a/src/components/k8s/examples/echoserver_nodeport.yaml
+++ b/src/components/k8s/examples/echoserver_nodeport.yaml
@@ -14,11 +14,14 @@ spec:
   selector:
     app: myechoserver
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: myechoserver
 spec:
+  selector:
+    matchLabels:
+      app: myechoserver
   replicas: 1
   template:
     metadata:

--- a/src/components/k8s/pcn-k8s.yaml
+++ b/src/components/k8s/pcn-k8s.yaml
@@ -32,12 +32,16 @@ data:
   # This is a temporary workaroud and should be fixed in the near future.
   vtepsRange: "10.18.0.0/16"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: polycube
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      k8s-app: polycube
+      kubernetes.io/cluster-service: "true"     
   template:
     metadata:
       labels:

--- a/src/components/k8s/standalone_etcd.yaml
+++ b/src/components/k8s/standalone_etcd.yaml
@@ -15,13 +15,16 @@ spec:
     polycube-app: etcd
   type: NodePort
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: polycube-etcd
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      polycube-app: etcd
   template:
     metadata:
       labels:


### PR DESCRIPTION
The newest version of Kubernetes, 1.16, has dropped support for resources that use `apiVersion: extensions/v1beta1`: this made `pcn-k8s` incompatible with Kubernetes 1.16, as some of its resources rely on that version.

This PR fixes this compatibility issue and updates documentation to specify the minimum Kubernetes version supported by pcn-k8s.