### PR TITLE
pr/profiling - Polycube Benchmarking Framework

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ off on commits in the Polycube repository:
   Nico Caprioli                           nico.caprioli@gmail.com
   Riccardo Marchi                         riccardo.marchi4@gmail.com
   Sebastiano Miano                        mianosebastiano@gmail.com
+  Simone Magnani                          simonemagnani.96@gmail.com
   Yunsong Lu                              roamer@yunsong.lu
 
 The following additional people are mentioned in commit logs as having provided

--- a/Documentation/developers/index.rst
+++ b/Documentation/developers/index.rst
@@ -16,9 +16,19 @@ The process to create or update service could be summarized in these steps:
 Please note that steps (1) and (2) are needed only when there is a change to the the YANG data model.
 In case we have to slightly modify an existing service (e.g., fixing a bug in the code), only steps (3) and (4) are required.
 
+
 Debugging Polycube services
 ---------------------------
 :doc:`See how to use the provided logging primitives <debugging>`
+
+
+How to benchmark code execution
+-------------------------------
+
+To measure time taken by functions, instructions or a whole service, an internal easy to use profiling framework can be used.
+
+Please follow the instructions in the guide :doc:`Profiling Polycube Framework <profiler>`.
+
 
 Some hints for programmers
 --------------------------

--- a/Documentation/developers/profiler.rst
+++ b/Documentation/developers/profiler.rst
@@ -1,0 +1,117 @@
+Profiler Framework
+^^^^^^^^^^^^^^^^^^
+
+Simple, easy to use and fast C++ header class framework for profiling and benchmark.
+
+Introduction
+************
+
+This framework provides an efficient and simple benchmarking primitive for user programs. Particularly, this can be used to profile the control plane portion of Polycube.
+Although there are several powerful tools (particularly in Linux) that target benchmarking and profiling, they are often difficult to learn for an occasional user, which may need to perform some simple and fast benchmarking.
+
+A worth-mentioning tool is  `perf <https://perf.wiki.kernel.org/index.php/Main_Page>`_. Perf is a Linux profiling tool with performance counters which helps users to understand at low-level how not only the program, but also the hardware behaves. As the wiki reports, this tool not only is quite complex to learn, but it also produces deep information that users may not use or that they have to aggregate them to achieve a readable result. Moreover, perf refers to different types of event (ex. I/O disk) users may not be interested in.
+
+This library provides a simple to use method not only to run a whole program benchmark, but also to measure single code-fragments performance.
+
+How it works
+************
+
+The framework defines two different main components:
+
+* Check-point: ``CHECKPOINT(<name>)``
+* Store-point: ``STOREPOINT(<name>)``
+
+A check-point is a point of the code where we simply want to take a measure (timestamp).
+
+A store-point is a specialized check-point which not only acts like it, but it also manages the data storing into a file.
+
+While the usage of a check-point leads to a negligible overhead (\~60 nanoseconds), it is suggested to use wisely the store-points, since the I/O operation on file are more expensive.
+
+Each measure is characterized by:
+
+* filename: the name of the file which contains the check-point;
+* line of code: the line of code where the check-point has been inserted;
+* name (optional): the name/description of the checkpoint given by the user;
+* timestamp: the measure in *nanoseconds* taken.
+
+Accordingly, the format used to store check-points is: `<filename>,<line_of_code>,<name>,<timestamp>`.
+
+The output file would be available at ``/var/log/polycube/profile_<date>_<time>).log`` where date and time refer to execution moment.
+
+Usage
+*****
+
+The framework is turned on by defining ``#define PROFILER`` in your code (wherever the user wants) but **before**  including the profiling header (i.e., `#include <polycube/profile.h>`). Without this definition, the framework will be automatically turned off for all the execution.
+
+Possible operations:
+
+* to insert Check-points, the user have just to insert the macro ``CHECKPOINT(<name>)``.
+* to insert Store-points, insert the macro ``STOREPOINT(<name>)``.
+* to remove them, comment the proper line or remove it.
+
+An interesting feature is that in case the user deactivates the framework, it is not required to remove every checkpoints he had previously inserted in the code: the framework will handle it by replacing them with an empty line.
+
+The output file created by the framework can be easily imported by every spreadsheet program (LibreOffice, Excel,...), but since it does not contain clear data, the user can use the script ``profiler_parser.py`` (Doc. inside the script) to achieve a more complete, elegant and importable as well result.
+
+Example
+*******
+
+In this simple program we want to measure the performance of our function to compute the square of a number. We insert two check-points between the functions call and a final store-point at the end.
+
+.. code-block:: c++
+ 
+ #define PROFILER
+ #include <polycube/profiler.h>
+ 
+ int main(int argc, char **argv) {
+   CHECKPOINT("Beginning")                 //line 7
+   computeSquare(1);
+   CHECKPOINT("After first computation")   //line 9
+   computeSquare(2);
+   STOREPOINT("After second computation")  //line 11
+   return 0;
+ }
+
+After the execution, we obtain the following `profile_20190902_181847.log` file:
+
+.. code-block:: txt
+
+ main.cpp,7,Beginning,1567333232104876595
+ main.cpp,9,After first computation,1567333232104876666
+ main.cpp,11,After second computation,1567333232104876737
+
+Since the stored timestamps refer to the start of the epoch, to beautify the data and print some statistics we use our script `profiler_parser.py`:
+
+.. code-block:: bash
+
+ $ python profiler_parser.py profile_20190902_181847.log
+
+ ========================================================================
+ ||FROM                   |TO                      |TIME(ns)           ||
+ ========================================================================
+ ||Beginning              |After first computation |71                 ||
+ ||After first computation|After second computation|71                 ||
+ ========================================================================
+ Max execution time: 71 ns
+ Min execution time: 71 ns
+ Avg execution time: 71.0 ns
+
+In case some checkpoint has not been given the name, the displayed information will follow the format
+``<file>,<line>`` in order to identify the checkpoint as well. The script has another feature available in case we
+would like to export data in .csv format: it can detect similar checkpoints inside a loop by comparing all the
+available information and it assigns them an additional identifier to clarify the differences among them.
+
+Performance analysis
+********************
+
+For this analysis, tests have been run on a Dell Xps 9570. Please consider that results are different depending on your processors and the available CPU.
+
+The test has been run on a simple file where we inserted 100 consecutively check-points and a final store-point. The check-points are inserted inside a loop and there is not any other function call except for the check-points themselves. The aim of this program is to measure the time taken by each `CHECKPOINT()` to perform and save the single measurement. The final store-points has not been taken into account in the performance analysis result, since the processor's BPU (branch predictor unit) would probably fail the prediction of the last loop cycle (which has to exit the loop), leading to some small delay.
+
+.. code-block:: bash
+
+ Max execution time: 69 ns
+ Min execution time: 46 ns
+ Avg execution time: 49.515151515151516 ns
+
+These results are really significant and they prove that the overhead added by the framework is small and does not interfere with the performance of calling program.

--- a/scripts/profiler_parser.py
+++ b/scripts/profiler_parser.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+
+"""
+Utility script to parse output from Profiler framework and print statistics.
+
+More information about the benchmarking framework can be found in the
+Polycube documentation, section 'developers/profiler.rst'.
+
+This is a script with the aim of printing in a more human-readable format
+information previously gathered by the framework.
+
+Usage: profiler_parse.py <filename> [<FLAGS>]
+    -h/--help: show the usage menu
+    -s/--statistics: show only general statistics
+    -e/--export: export in csv format
+"""
+
+import sys
+import re
+import csv
+
+#Support variable
+data = []
+previous = 0
+padding = 40
+
+#Pattern to match. The framework's output file is:
+#<filename>,<line_of_code>:<timestamp>
+pattern = '(\\S+),(\\d+),(.*),(\\d+)'
+
+#Function to parse a matched line
+def parseMatch(match, number):
+  global data, padding, previous
+  #Used last string from '/' since the __FILE__ macro in C
+  #could contain the entire path
+  file = match.group(1)[match.group(1).rfind('/')+1:]
+  line = int(match.group(2))
+  name = match.group(3)
+  loopId = len([1 for x in data if x[0] == file and x[1] == line])
+  timestamp = int(match.group(4))
+  duration = 0 if number == 0 else timestamp - previous
+  previous = timestamp
+  padding = padding if len(file)+len(str(line))+1 < padding else len(file)+len(str(line))+1
+  padding = padding if len(name) < padding else len(name)
+  data.append((file,line,name,loopId,timestamp,duration))
+
+#Function to read the specified file
+def readFile(filename):
+  try:
+    lines = open(filename, 'r').readlines()
+    if len(lines) == 0:
+        raise IOError()
+  except IOError:
+    print('Error: no such file \'' + sys.argv[1] + '\' or empty')
+    exit()
+  #Foreach line read, parse it and update data structures
+  for line_number, line in enumerate(lines[1:]):
+    match = re.match(pattern, line, flags=0)
+    if match:
+        parseMatch(match, line_number)
+    else:
+      print("Error while parsing line " + str(line_number) + ": " + line)
+      print("Is it compliant with the format <file>,<line_of_code>,<checkpoint_name>,<timestamp> ?\n")
+      showUsage()
+      exit()
+
+#Function to print script usage
+def showUsage():
+  print("profiler_parser.py <filename> [<FLAGS>]")
+  print("\t-h/--help: show the usage menu")
+  print("\t-s/--statistics: show only general statistics")
+  print("\t-e/--export: export in csv format")
+
+def main():
+  global data
+
+  #Checking arguments
+  if len(sys.argv) == 1 or sys.argv[1] == "-h" or sys.argv[1] == "--help":
+    showUsage()
+    exit()
+
+  readFile(sys.argv[1])
+
+  #Checking export flag
+  if len(sys.argv) == 3 and (sys.argv[2] == "--export" or sys.argv[2] == "-e"):
+    filename = sys.argv[1][:sys.argv[1].rfind('.')]+".csv"
+    with open(filename, 'w') as out:
+      csv_out=csv.writer(out)
+      csv_out.writerow(["File", "Line", "Name", "LoopId", "Timestamp(ns)", "Duration(ns)"])
+      for row in data:
+        csv_out.writerow(row)
+    print("CSV exported at `" + filename + "`")
+    exit()
+
+  #Checking whether to display all point-to-point distances or not
+  if len(sys.argv) == 2 or (len(sys.argv) == 3 and not (sys.argv[2] == "--statistics" or sys.argv[2] == "-s")):
+    print("="*padding*3 + "="*6)
+    print("||" + "FROM".ljust(padding) + "|" + "TO".ljust(padding) + "|" + "TIME(ns)".ljust(padding) + "||")
+    print("="*padding*3 + "="*6)
+    for count, item in enumerate(data[:-1]):
+      name1 = item[2] if item[2] != "" else item[0] + "," +str(item[1])
+      name2 = data[count+1][2] if data[count+1][2] != "" else data[count+1][0] + "," + str(data[count+1][1])
+      print("||" + name1.ljust(padding) + "|" + name2.ljust(padding) + "|" + str(data[count+1][5]).ljust(padding) + "||")
+    print("="*padding*3 + "="*6)
+
+  #Printing statistics
+  duration = [item[5] for item in data[1:]]
+  print("Max execution time: " + str(max(duration)) + " ns")
+  print("Min execution time: " + str(min(duration)) + " ns")
+  print("Avg execution time: " + str(sum(duration)/len(duration)) + " ns")
+
+if __name__== '__main__':
+    main()

--- a/src/libs/polycube/include/polycube/profiler.h
+++ b/src/libs/polycube/include/polycube/profiler.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019 The Polycube Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef PROFILER
+
+#ifndef POLYCUBE_PROFILER_H
+#define POLYCUBE_PROFILER_H
+
+#include <algorithm>
+#include <chrono>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#define WARM_UP 100
+
+#define PROFILER_FILENAME "/var/log/polycube/profile"
+#define PROFILER_EXTENSION ".log"
+
+#define CHECKPOINT(...) \
+  Profiler::getInstance().tick(__FILE__, __LINE__, ##__VA_ARGS__);
+#define STOREPOINT(...) \
+  { CHECKPOINT(__VA_ARGS__) Profiler::getInstance().store(); }
+
+/***
+ * Profiler Singleton header class to measure execution time of certain
+ * functions
+ */
+class Profiler {
+ private:
+  /// Private class constructor to avoid instantiation, includes a warm-up phase
+  /// for the timer and cache loading
+  Profiler();
+
+  /// Support data structure <file,line><checkpoint_name,timestamp>
+  std::vector<std::pair<
+      std::pair<const char *, unsigned>,
+      std::pair<const char *, std::chrono::high_resolution_clock::time_point>>>
+      results;
+
+  /// Final filename calculated at execution time
+  std::string output_file;
+
+ public:
+  /**
+   * Function to be called before the `objective function` execution to store
+   * the initial timestamp
+   * @param file: the name of the file containing the checkpoint
+   * @param line: the line of code where the checkpoint is
+   * @param checkpoint_name: user defined checkpoint name
+   */
+  void tick(const char *file = "", unsigned line = 0,
+            const char *checkpoint_name = "");
+
+  /// Function called to store gathered data into a file
+  void store();
+
+  /// Singleton implementation, method to return the instance
+  static Profiler &getInstance() {
+    static Profiler instance;
+    return instance;
+  }
+};
+
+inline Profiler::Profiler() {
+  auto now = time(nullptr);
+  auto ltm = localtime(&now);
+
+  // Setting output file file according to template: <filename>_YYYYMMDD_HHMMSS
+  output_file = dynamic_cast<std::ostringstream &>(
+                    std::ostringstream().seekp(0)
+                    << PROFILER_FILENAME << "_" << std::setw(4)
+                    << 1900 + ltm->tm_year << std::setfill('0') << std::setw(2)
+                    << 1 + ltm->tm_mon << std::setfill('0') << std::setw(2)
+                    << ltm->tm_mday << "_" << std::setfill('0') << std::setw(2)
+                    << ltm->tm_hour << std::setfill('0') << std::setw(2)
+                    << ltm->tm_min << std::setfill('0') << std::setw(2)
+                    << ltm->tm_sec << PROFILER_EXTENSION)
+                    .str();
+
+  // Creating file and changing permissions to make it writable also by normal
+  // user. This is extremely necessary since the user could insert a CHECKPOINT
+  // in some part of the code which is executed by root. If the output file is
+  // created in that moment, the ones inserted in a non-root part of the code
+  // would not be stored due to lower permissions.
+  std::ofstream os;
+  os.open(output_file, std::ios::out);
+  os << "File, Line, Checkpoint Name, Timestamp" << std::endl;
+  os.close();
+  chmod(output_file.c_str(), S_IRWXO | S_IRWXG | S_IRWXU);
+
+  // Warm up phase for timer and cache
+  for (int i = 0; i < WARM_UP; i++) {
+    tick();
+  }
+  results.clear();
+}
+
+inline void Profiler::store() {
+  std::ofstream os;
+  os.open(output_file, std::ios::app);
+  std::for_each(results.begin(), results.end(), [&os](auto &res) -> void {
+    os << res.first.first << "," << res.first.second << "," << res.second.first
+       << "," << res.second.second.time_since_epoch().count() << std::endl;
+  });
+  os.close();
+  results.clear();
+}
+
+inline void Profiler::tick(const char *filename, unsigned line_number,
+                           const char *checkpoint_name) {
+  results.emplace_back(std::make_pair(
+      std::make_pair(filename, line_number),
+      std::make_pair(checkpoint_name,
+                     std::chrono::high_resolution_clock::now())));
+}
+
+#endif  // POLYCUBE_PROFILER_H
+
+#else
+
+#define CHECKPOINT(...)
+#define STOREPOINT(...)
+
+#endif  // PROFILER

--- a/src/polycubed/src/controller.cpp
+++ b/src/polycubed/src/controller.cpp
@@ -95,7 +95,7 @@ ERROR:
 const std::string CTRL_TC_RX = R"(
 #include <bcc/helpers.h>
 #include <bcc/proto.h>
-#include <linux/kernel.h>
+#include <uapi/linux/bpf.h>
 #include <linux/skbuff.h>
 
 #include <linux/rcupdate.h>


### PR DESCRIPTION
## Polycube Benchmarking Framework pull request. (Issue #191)

Pull request of the profiling framework developed as a header class library.

### Results on Polycubed startup
​
The developed framework has been used to measure time taken by Polycubed to start.

```bash
Old include in controller.cpp line 98 => `#include <linux/kernel.h> `
​
=============================================================================================================================================
||FROM                                         |TO                                           |TIME(ns)                                     ||
=============================================================================================================================================
||Start                                        |Start+1                                      |145                                          ||
||Start+1                                      |Before config.load                           |15973                                        ||
||Before config.load                           |Before config.dump                           |533138                                       ||
||Before config.dump                           |After config.dump                            |615082                                       ||
||After config.dump                            |Before daemonize                             |105088                                       ||
||Before daemonize                             |After daemonize                              |563                                          ||
||After daemonize                              |After instance check and sigInt              |24443                                        ||
||After instance check and sigInt              |PatchPanel::get_tc_instance                  |116370835                                    ||
||PatchPanel::get_tc_instance                  |PatchPanel::get_xdp_instance                 |99546704                                     ||
||PatchPanel::get_xdp_instance                 |Controller::get_tc_instance                  |1396687149                                   ||
||Controller::get_tc_instance                  |Controller::get_xdp_instance                 |471426643                                    ||
||Controller::get_xdp_instance                 |After BaseModel and PolycubedCore declaration|33164                                        ||
||After BaseModel and PolycubedCore declaration|After RestServer declaration                 |228881                                       ||
||After RestServer declaration                 |After RestServer init                        |374277                                       ||
||After RestServer init                        |After Core set RestServer                    |590                                          ||
||After Core set RestServer                    |After RestServer start                       |21121544                                     ||
||After RestServer start                       |After load_services                          |408682495                                    ||
||After load_services                          |After cubes dump enabled check               |1312                                         ||
=============================================================================================================================================
Max execution time: 1396687149 ns
Min execution time: 145 ns
Avg execution time: 139764890 ns
```
​
As suggested by Sebastiano, replacing the include at line 98 led to a faster start-up phase (~0.3seconds).

```bash
New include in controller.cpp line 98 => `#include <uapi/linux/bpf.h>`
​
=============================================================================================================================================
||FROM                                         |TO                                           |TIME(ns)                                     ||
=============================================================================================================================================
||Start                                        |Start+1                                      |108                                          ||
||Start+1                                      |Before config.load                           |14467                                        ||
||Before config.load                           |Before config.dump                           |560586                                       ||
||Before config.dump                           |After config.dump                            |88311                                        ||
||After config.dump                            |Before daemonize                             |12324                                        ||
||Before daemonize                             |After daemonize                              |152                                          ||
||After daemonize                              |After instance check and sigInt              |15535                                        ||
||After instance check and sigInt              |PatchPanel::get_tc_instance                  |86126669                                     ||
||PatchPanel::get_tc_instance                  |PatchPanel::get_xdp_instance                 |71818684                                     ||
||PatchPanel::get_xdp_instance                 |Controller::get_tc_instance                  |1029723499                                   ||
||Controller::get_tc_instance                  |Controller::get_xdp_instance                 |357891272                                    ||
||Controller::get_xdp_instance                 |After BaseModel and PolycubedCore declaration|7689                                         ||
||After BaseModel and PolycubedCore declaration|After RestServer declaration                 |186975                                       ||
||After RestServer declaration                 |After RestServer init                        |338348                                       ||
||After RestServer init                        |After Core set RestServer                    |532                                          ||
||After Core set RestServer                    |After RestServer start                       |17426496                                     ||
||After RestServer start                       |After load_services                          |295403771                                    ||
||After load_services                          |After cubes dump enabled check               |995                                          ||
=============================================================================================================================================
Max execution time: 1029723499 ns
Min execution time: 108 ns
Avg execution time: 103312022 ns
```
​
These results point-out a 0.3 second difference on average on the slower function. The time taken is not always the same, it depends by execution to execution, but on average it turned out to be slightly improved by modifying the file according to what Sebastiano told. (Test run on a VM)