### PR TITLE
Removing references to polycube-tools

### DIFF
--- a/Documentation/developers/debugging.rst
+++ b/Documentation/developers/debugging.rst
@@ -75,8 +75,6 @@ The ``pcn_pkt_log(ctx, level)`` primitive sends a packet to the control plane wh
 `ctx` and `level` are the same as in `pcn_log`.
 This feature is only designed for developers, so final version of services should not include this.
 
-`polycube-tools <https://github.com/mauriciovasquezbernal/polycube-tools>`_ must be installed and ``polycube`` cmake must be configured with `cmake -DHAVE_POLYCUBE_TOOLS=ON ..`
-
 Usage example:
 
 ::

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,12 +3,7 @@ find_package(LibYANG REQUIRED)
 include_directories(${CMAKE_SOURCE_DIR}/src/libs/bcc/src/cc/libbpf/include/uapi)
 
 option(INSTALL_CLI "installs the polycube CLI" ON)
-option(HAVE_POLYCUBE_TOOLS "uses the polycube-tools package" OFF)
 option(ENABLE_PCN_IPTABLES "enables the pcn-iptables" OFF)
-
-if (HAVE_POLYCUBE_TOOLS)
-  add_definitions(-DHAVE_POLYCUBE_TOOLS)
-endif (HAVE_POLYCUBE_TOOLS)
 
 add_subdirectory(components)
 add_subdirectory(libs)
@@ -22,5 +17,3 @@ add_subdirectory(polycubed)
 if (INSTALL_CLI)
   add_subdirectory(polycubectl)
 endif (INSTALL_CLI)
-
-

--- a/src/libs/polycube/include/polycube/services/utils.h
+++ b/src/libs/polycube/include/polycube/services/utils.h
@@ -80,10 +80,6 @@ void split_ip_and_prefix(const std::string &ip_and_prefix,
  */
 std::string format_debug_string(std::string str, const uint64_t args[4]);
 
-#ifdef HAVE_POLYCUBE_TOOLS
-void print_packet(const uint8_t *pkt, uint32_t len);
-#endif
-
 }  // namespace utils
 }  // namespace service
 }  // namespace polycube

--- a/src/libs/polycube/src/base_cube.cpp
+++ b/src/libs/polycube/src/base_cube.cpp
@@ -74,16 +74,6 @@ void BaseCube::datapath_log_msg(const LogMsg *msg) {
     logger()->log(level_, print.c_str());
     break;
 
-  case 1:
-#ifdef HAVE_POLYCUBE_TOOLS
-    logger()->log(level_, "packet received for debug:");
-    utils::print_packet((const uint8_t *)msg->msg, msg->len);
-#else
-    logger()->warn(
-        "Received packet for debugging. polycube-tools is not available");
-#endif
-    break;
-
   default:
     logger()->warn("Received bad message type in datapath_log_msg");
     return;

--- a/src/libs/polycube/src/utils.cpp
+++ b/src/libs/polycube/src/utils.cpp
@@ -29,12 +29,6 @@
 
 #include <api/BPFTable.h>
 
-#ifdef HAVE_POLYCUBE_TOOLS
-#include <polycube/tools/netdissect/netdissect-stdinc.h>
-#include <polycube/tools/netdissect/netdissect.h>
-#include <polycube/tools/netdissect/print.h>
-#endif
-
 namespace polycube {
 namespace service {
 namespace utils {
@@ -200,33 +194,6 @@ std::string format_debug_string(std::string str, const uint64_t args[4]) {
 
   return std::string(buf);
 }
-
-#ifdef HAVE_POLYCUBE_TOOLS
-void print_packet(const uint8_t *pkt, uint32_t len) {
-  netdissect_options Ndo;
-  netdissect_options *ndo = &Ndo;
-
-  memset(ndo, 0, sizeof(*ndo));
-  char ebuf[100];
-  // if (nd_init(ebuf, sizeof(ebuf)) == -1)
-  //  return;
-
-  ndo_set_function_pointers(ndo);
-
-  ndo->ndo_nflag = 1;
-  ndo->ndo_vflag = 0;
-  // ndo->ndo_qflag = 1;
-  ndo->ndo_tflag = 0;
-  const char name[] = "helloworld";
-  ndo->program_name = name;
-  ndo->ndo_eflag = 1;  // print ethernet packet
-  init_print(ndo, 0, 0, 0);
-  ndo->ndo_if_printer = get_if_printer(ndo, 0);
-
-  struct pcap_pkthdr hdr = {{0, 0}, len, len};
-  pretty_print_packet(ndo, &hdr, pkt, 0);
-}
-#endif
 
 std::string get_random_mac() {
   std::random_device rd;

--- a/src/polycubed/src/CMakeLists.txt
+++ b/src/polycubed/src/CMakeLists.txt
@@ -87,10 +87,6 @@ set(polycubed_libraries
   ${TINS_LIBRARIES}
 )
 
-if (HAVE_POLYCUBE_TOOLS)
-  set (polycubed_libraries ${polycubed_libraries} polycube-tools)
-endif (HAVE_POLYCUBE_TOOLS)
-
 target_link_libraries(polycubed
         ${polycubed_libraries})
 


### PR DESCRIPTION
This PR removes all the references to polycube-tools from source code and documentation.