### PR TITLE
Refactoring service::Sense to service::Direction

### DIFF
--- a/src/libs/polycube/include/polycube/services/cube_iface.h
+++ b/src/libs/polycube/include/polycube/services/cube_iface.h
@@ -37,7 +37,7 @@ enum class ProgramType {
   EGRESS,
 };
 
-enum class Sense {
+enum class Direction {
   INGRESS,
   EGRESS,
 };
@@ -98,7 +98,7 @@ class TransparentCubeIface : virtual public BaseCubeIface {
   virtual void set_next(uint16_t next, ProgramType type) = 0;
   virtual void set_parameter(const std::string &parameter,
                              const std::string &value) = 0;
-  virtual void send_packet_out(const std::vector<uint8_t> &packet, Sense sense,
+  virtual void send_packet_out(const std::vector<uint8_t> &packet, Direction direction,
                                bool recirculate = false) = 0;
 
   virtual void set_conf(const nlohmann::json &conf) = 0;

--- a/src/libs/polycube/include/polycube/services/transparent_cube.h
+++ b/src/libs/polycube/include/polycube/services/transparent_cube.h
@@ -46,10 +46,10 @@ class TransparentCube : public BaseCube {
                   const std::vector<std::string> &egress_code);
   virtual ~TransparentCube();
 
-  virtual void packet_in(Sense sense, PacketInMetadata &md,
+  virtual void packet_in(Direction direction, PacketInMetadata &md,
                          const std::vector<uint8_t> &packet) = 0;
 
-  void send_packet_out(EthernetII &packet, Sense sense,
+  void send_packet_out(EthernetII &packet, Direction direction,
                        bool recirculate = false);
 
   void set_conf(const nlohmann::json &conf);

--- a/src/libs/polycube/src/transparent_cube.cpp
+++ b/src/libs/polycube/src/transparent_cube.cpp
@@ -33,13 +33,13 @@ TransparentCube::TransparentCube(const nlohmann::json &conf,
     if (dismounted_)
       return;
 
-    Sense sense = static_cast<Sense>(md->port_id);
+    Direction direction = static_cast<Direction>(md->port_id);
     PacketInMetadata md_;
     md_.reason = md->reason;
     md_.metadata[0] = md->metadata[0];
     md_.metadata[1] = md->metadata[1];
     md_.metadata[2] = md->metadata[2];
-    packet_in(sense, md_, packet);
+    packet_in(direction, md_, packet);
   };
 
   cube_ = factory_->create_transparent_cube(
@@ -60,9 +60,9 @@ TransparentCube::~TransparentCube() {
   factory_->destroy_cube(get_name());
 }
 
-void TransparentCube::send_packet_out(EthernetII &packet, Sense sense,
+void TransparentCube::send_packet_out(EthernetII &packet, Direction direction,
                                       bool recirculate) {
-  cube_->send_packet_out(packet.serialize(), sense, recirculate);
+  cube_->send_packet_out(packet.serialize(), direction, recirculate);
 }
 
 void TransparentCube::set_conf(const nlohmann::json &conf) {

--- a/src/polycubed/src/transparent_cube.cpp
+++ b/src/polycubed/src/transparent_cube.cpp
@@ -93,7 +93,7 @@ void TransparentCube::set_parameter(const std::string &parameter,
 }
 
 void TransparentCube::send_packet_out(const std::vector<uint8_t> &packet,
-                                      service::Sense sense, bool recirculate) {
+                                      service::Direction direction, bool recirculate) {
   Controller &c = (get_type() == CubeType::TC) ? Controller::get_tc_instance()
                                                : Controller::get_xdp_instance();
 
@@ -103,12 +103,12 @@ void TransparentCube::send_packet_out(const std::vector<uint8_t> &packet,
   Port *parent = dynamic_cast<Port *>(parent_);
 
   // calculate port
-  switch (sense) {
-  case service::Sense::INGRESS:
+  switch (direction) {
+  case service::Direction::INGRESS:
     // packet is comming in, port is ours
     port = parent->index();
     break;
-  case service::Sense::EGRESS:
+  case service::Direction::EGRESS:
     // packet is going, set port to next one
     if (parent->peer_port_) {
       port = parent->peer_port_->get_port_id();
@@ -117,15 +117,15 @@ void TransparentCube::send_packet_out(const std::vector<uint8_t> &packet,
   }
 
   // calculate module index
-  switch (sense) {
-  case service::Sense::INGRESS:
+  switch (direction) {
+  case service::Direction::INGRESS:
     if (recirculate) {
       module = ingress_index_;  // myself in ingress
     } else {
       module = ingress_next_;
     }
     break;
-  case service::Sense::EGRESS:
+  case service::Direction::EGRESS:
     if (recirculate) {
       module = egress_index_;  // myself in egress
     } else {

--- a/src/polycubed/src/transparent_cube.h
+++ b/src/polycubed/src/transparent_cube.h
@@ -39,7 +39,7 @@ class TransparentCube : public BaseCube, public TransparentCubeIface {
   void set_parent(PeerIface *parent);
   PeerIface *get_parent();
   void set_parameter(const std::string &parameter, const std::string &value);
-  void send_packet_out(const std::vector<uint8_t> &packet, service::Sense sense,
+  void send_packet_out(const std::vector<uint8_t> &packet, service::Direction direction,
                        bool recirculate = false);
 
   void set_conf(const nlohmann::json &conf);

--- a/src/services/pcn-ddosmitigator/src/Ddosmitigator.cpp
+++ b/src/services/pcn-ddosmitigator/src/Ddosmitigator.cpp
@@ -82,7 +82,7 @@ DdosmitigatorJsonObject Ddosmitigator::toJsonObject() {
   return conf;
 }
 
-void Ddosmitigator::packet_in(polycube::service::Sense sense,
+void Ddosmitigator::packet_in(polycube::service::Direction direction,
                               polycube::service::PacketInMetadata &md,
                               const std::vector<uint8_t> &packet) {
   logger()->info("packet in event");

--- a/src/services/pcn-ddosmitigator/src/Ddosmitigator.h
+++ b/src/services/pcn-ddosmitigator/src/Ddosmitigator.h
@@ -39,7 +39,7 @@ class Ddosmitigator : public polycube::service::TransparentCube,
   void update(const DdosmitigatorJsonObject &conf) override;
   DdosmitigatorJsonObject toJsonObject() override;
 
-  void packet_in(polycube::service::Sense sense,
+  void packet_in(polycube::service::Direction direction,
                  polycube::service::PacketInMetadata &md,
                  const std::vector<uint8_t> &packet) override;
 

--- a/src/services/pcn-firewall/src/Firewall.cpp
+++ b/src/services/pcn-firewall/src/Firewall.cpp
@@ -95,14 +95,14 @@ Firewall::~Firewall() {
   TransparentCube::dismount();
 }
 
-void Firewall::packet_in(polycube::service::Sense sense,
+void Firewall::packet_in(polycube::service::Direction direction,
                                       polycube::service::PacketInMetadata &md,
                                       const std::vector<uint8_t> &packet) {
-  switch (sense) {
-  case polycube::service::Sense::INGRESS:
+  switch (direction) {
+  case polycube::service::Direction::INGRESS:
     logger()->info("packet in event from ingress program");
     break;
-  case polycube::service::Sense::EGRESS:
+  case polycube::service::Direction::EGRESS:
     logger()->info("packet in event from egress program");
     break;
   }

--- a/src/services/pcn-firewall/src/Firewall.h
+++ b/src/services/pcn-firewall/src/Firewall.h
@@ -63,7 +63,7 @@ class Firewall : public FirewallBase {
  public:
   Firewall(const std::string name, const FirewallJsonObject &conf);
   virtual ~Firewall();
-  void packet_in(polycube::service::Sense sense,
+  void packet_in(polycube::service::Direction direction,
                  polycube::service::PacketInMetadata &md,
                  const std::vector<uint8_t> &packet) override;
 

--- a/src/services/pcn-nat/src/Nat.cpp
+++ b/src/services/pcn-nat/src/Nat.cpp
@@ -83,7 +83,7 @@ NatJsonObject Nat::toJsonObject() {
   return conf;
 }
 
-void Nat::packet_in(polycube::service::Sense sense,
+void Nat::packet_in(polycube::service::Direction direction,
                     polycube::service::PacketInMetadata &md,
                     const std::vector<uint8_t> &packet) {
   logger()->info("packet in event");

--- a/src/services/pcn-nat/src/Nat.h
+++ b/src/services/pcn-nat/src/Nat.h
@@ -64,7 +64,7 @@ class Nat : public polycube::service::TransparentCube, public NatInterface {
   void update(const NatJsonObject &conf) override;
   NatJsonObject toJsonObject() override;
 
-  void packet_in(polycube::service::Sense sense,
+  void packet_in(polycube::service::Direction direction,
                  polycube::service::PacketInMetadata &md,
                  const std::vector<uint8_t> &packet) override;
 

--- a/src/services/pcn-synflood/src/Synflood.cpp
+++ b/src/services/pcn-synflood/src/Synflood.cpp
@@ -23,7 +23,7 @@ Synflood::~Synflood() {
   logger()->debug("Destroying Synflood instance");
 }
 
-void Synflood::packet_in(polycube::service::Sense sense,
+void Synflood::packet_in(polycube::service::Direction direction,
   polycube::service::PacketInMetadata &md,
   const std::vector<uint8_t> &packet) {
   logger()->debug("Packet received");

--- a/src/services/pcn-synflood/src/Synflood.h
+++ b/src/services/pcn-synflood/src/Synflood.h
@@ -27,7 +27,7 @@ class Synflood : public SynfloodBase {
   Synflood(const std::string name, const SynfloodJsonObject &conf);
   virtual ~Synflood();
 
-  void packet_in(polycube::service::Sense sense,
+  void packet_in(polycube::service::Direction direction,
                  polycube::service::PacketInMetadata &md,
                  const std::vector<uint8_t> &packet) override;
 

--- a/src/services/pcn-transparent-helloworld/src/Transparenthelloworld.cpp
+++ b/src/services/pcn-transparent-helloworld/src/Transparenthelloworld.cpp
@@ -57,14 +57,14 @@ TransparenthelloworldJsonObject Transparenthelloworld::toJsonObject() {
   return conf;
 }
 
-void Transparenthelloworld::packet_in(polycube::service::Sense sense,
+void Transparenthelloworld::packet_in(polycube::service::Direction direction,
                                       polycube::service::PacketInMetadata &md,
                                       const std::vector<uint8_t> &packet) {
-  switch (sense) {
-  case polycube::service::Sense::INGRESS:
+  switch (direction) {
+  case polycube::service::Direction::INGRESS:
     logger()->info("packet in event from ingress program");
     break;
-  case polycube::service::Sense::EGRESS:
+  case polycube::service::Direction::EGRESS:
     logger()->info("packet in event from egress program");
     break;
   }

--- a/src/services/pcn-transparent-helloworld/src/Transparenthelloworld.h
+++ b/src/services/pcn-transparent-helloworld/src/Transparenthelloworld.h
@@ -36,7 +36,7 @@ class Transparenthelloworld : public polycube::service::TransparentCube,
   virtual ~Transparenthelloworld();
 
   void attach() override;
-  void packet_in(polycube::service::Sense sense,
+  void packet_in(polycube::service::Direction direction,
                  polycube::service::PacketInMetadata &md,
                  const std::vector<uint8_t> &packet) override;
   void update(const TransparenthelloworldJsonObject &conf) override;


### PR DESCRIPTION
As "Sense" is not the correct term to indicate the direction of a packet that arrives to a service port, this PR renames it as Direction.