### PR TITLE
Fixing jenkins pipeline & tests

### DIFF
--- a/CI/JenkinsfileTestCleanInstance
+++ b/CI/JenkinsfileTestCleanInstance
@@ -5,7 +5,7 @@ def slackNotification(buildStatus,String notification_url = "",project_name = ""
         title = "${BRANCH_NAME} - BUILD UNSTABLE on ${project_name}"
         text = "Build n°${BUILD_NUMBER} of branch ${BRANCH_NAME} unstable (${BUILD_URL})"
         colorCode = '#FFFF00'
-    } else if (buildStatus == 'SUCCESSFUL') {
+    } else if (buildStatus == 'SUCCESS') {
         text = "Build n°${BUILD_NUMBER} of branch ${BRANCH_NAME} successful (${BUILD_URL})"
         title = "${BRANCH_NAME} - BUILD SUCCESS on ${project_name}"
         colorCode = '#00FF00'
@@ -16,11 +16,11 @@ def slackNotification(buildStatus,String notification_url = "",project_name = ""
     } else {
         echo "The build status is: ${buildStatus}"
         title = "${BRANCH_NAME} - BUILD FAILED on ${project_name}"
-        text = "Build n°${BUILD_NUMBER} of branch ${BRANCH_NAME} failed (${BUILD_URL})"
+        text = "Build n°${BUILD_NUMBER} of branch ${BRANCH_NAME} failed with status ${buildStatus} (${BUILD_URL})"
         colorCode = '#FF0000'
     }
 
-def payload= JsonOutput.toJson(
+    def payload= JsonOutput.toJson(
         [
             attachments: [
                 [
@@ -34,7 +34,6 @@ def payload= JsonOutput.toJson(
 
     sh "curl -X POST --fail -H 'Content-type: application/json' --data '${payload}' ${notification_url}"
 }
-
 
 /**
 * Trigger Github PR Check ( can be : error, failure, pending, or success)
@@ -58,331 +57,370 @@ pipeline {
     agent {
         label 'docker'
     }
+    triggers {
+        cron( env.BRANCH_NAME == 'master' ? '0 2 * * *' : '' )
+    }
     options {
         disableConcurrentBuilds()
         timeout(time: 4, unit: 'HOURS')
         buildDiscarder(logRotator(numToKeepStr: '30'))
     }
-
     environment {
-      image_tag = "${env.GIT_COMMIT}"
-      image_name = "polycube"
-      registryCred = credentials('polycube-repo')
-      notification_url = credentials('slack-notifications')
-      github_token = credentials('github_status_update')
+        image_tag = "${env.GIT_COMMIT}"
+        image_name = "polycube"
+        registryCred = credentials('polycube-repo')
+        notification_url = credentials('slack-notifications')
+        github_token = credentials('github_status_update')
     }
-
     stages {
-
-    stage ('Build Base Image') {
-    agent {
-             label "docker"
-    }
-     steps {
-        script {
-                 commit_id = sh returnStdout: true, script: "git rev-parse HEAD"
-                 setGithubStatus("${commit_id}", "pending", github_token, "polycube-network/polycube", "Same Instance Tests", "Same Instance Tests")
-                 setGithubStatus("${commit_id}", "pending", github_token, "polycube-network/polycube", "Iptables Tests", "Iptables Tests")
-                 setGithubStatus("${commit_id}", "pending", github_token, "polycube-network/polycube", "Clean Instance Tests", "Clean Instance Tests")
-                 setGithubStatus("${commit_id}", "pending", github_token, "polycube-network/polycube", "Docker Image Build", "Docker Image Build")
-                 slackNotification("STARTED",notification_url,"Polycube")
-                 docker.withRegistry("", 'polycube-repo') {
-                 sh """export DOCKER_BUILDKIT=1
-                     docker system prune --all --force
-                     docker build . -t "polycubebot/base_image:latest" -f Dockerfile_base_image
-                     docker push polycubebot/base_image:latest
-            """
+        stage ('Init Notification Handlers') {
+            agent {
+              label "docker"
+            }
+            steps {
+                script {
+                    commit_id = sh returnStdout: true, script: "git rev-parse HEAD"
+                    setGithubStatus("${commit_id}", "pending", github_token, "polycube-network/polycube", "Same Instance Tests", "Same Instance Tests")
+                    setGithubStatus("${commit_id}", "pending", github_token, "polycube-network/polycube", "Iptables Tests", "Iptables Tests")
+                    setGithubStatus("${commit_id}", "pending", github_token, "polycube-network/polycube", "Clean Instance Tests", "Clean Instance Tests")
+                    setGithubStatus("${commit_id}", "pending", github_token, "polycube-network/polycube", "Docker Image Build", "Docker Image Build")
+                    slackNotification("STARTED",notification_url,"Polycube")
+                }
             }
         }
-      }
-     post {
-        failure {
-          script {
-            setGithubStatus("${commit_id}", "pending", github_token, "polycube-network/polycube", "Docker Image Build", "Docker Image Build")
-          }
-        }
-      }
-    }
-   stage('Parallel Docker Build') {
-   parallel {
-    stage("Build Docker Mode: default") {
-       agent {
-             label "docker"
-       }
-       steps {
-       script {
-        docker.withRegistry("", 'polycube-repo') {
-        sh """export DOCKER_BUILDKIT=1
-        docker system prune --all --force
-        docker build . -t "polycubebot/${image_name}-default:${image_tag}" --build-arg DEFAULT_MODE=default
-        docker push polycubebot/${image_name}-default:${image_tag}
-        """
-        }
-    }
-    }
-    }
-
-    stage("Build Docker Mode: pcn-k8s") {
-       agent {
-             label "docker"
-       }
-       steps {
-       script {
-        docker.withRegistry("", 'polycube-repo') {
-        sh """export DOCKER_BUILDKIT=1
-        docker system prune --all --force
-        docker build . -t "polycubebot/${image_name}-pcn-k8s:${image_tag}" --build-arg DEFAULT_MODE=pcn-k8s
-        docker push polycubebot/${image_name}-pcn-k8s:${image_tag}
-        """
-        }
-    }
-    }
-    }
-
-
-    stage("Build Docker Mode: pcn-iptables") {
-       agent {
-             label "docker"
-       }
-       steps {
-       script {
-        docker.withRegistry("", 'polycube-repo') {
-        sh """export DOCKER_BUILDKIT=1
-        docker system prune --all --force
-        docker build . -t "polycubebot/${image_name}-pcn-iptables:${image_tag}" --build-arg DEFAULT_MODE=pcn-iptables
-        docker push polycubebot/${image_name}-pcn-iptables:${image_tag}
-        """
-        }
-    }
-    }
-    }
-    }
-    post {
-        failure {
-          script {
-            setGithubStatus("${commit_id}", "failure", github_token, "polycube-network/polycube", "Docker Image Build", "Docker Image Build")
-          }
-        }
-        success {
-          script {
-           setGithubStatus("${commit_id}", "success", github_token, "polycube-network/polycube", "Docker Image Build", "Docker Image Build")
-          }
-        }
-      }
-    }
-
-    stage('Testing') {
-     parallel {
-    stage('Launch Clean Instance Tests') {
-    agent {
-             label "docker && testing-2"
-       }
-       steps {
-       script {
-        docker.withRegistry("", 'polycube-repo') {
-           sh"""
-           sleep 60
-           # Launch the polycubed daemon and extract the polycubectl
-           docker run -d --name polycubed --rm --privileged --network host -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -v /etc/localtime:/etc/localtime:ro polycubebot/${image_name}-default:${image_tag}
-           mkdir bin
-           docker cp polycubed:/usr/local/bin/polycubectl ./bin/
-           # Overload environment variables in order to adapt the behavior of run_tests script
-           export PATH=$PATH:${WORKSPACE}/bin
-           export KILL_COMMAND="docker stop polycubed"
-           export polycubed="docker run -d --name polycubed --rm --privileged --network host -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -v /etc/localtime:/etc/localtime:ro polycubebot/${image_name}-default:${image_tag}"
-           cd tests/
-           # For the moment, tests always returns 0 to enable junit generation
-           ./run-tests.sh || true
-           export LC_ALL=C
-           virtualenv venv -p python3
-           . venv/bin/activate
-           pip install -r converter/requirements.txt
-           export TEST_RESULTS=`ls -1 test_results_*`
-           python3 converter/to_junit.py CleanInstance
-           """
-       }
-       }
-       }
-       post {
-
-        always {
-           dir(".") {
-                junit allowEmptyResults: true, testResults: "tests/output.xml"
-                archiveArtifacts artifacts: 'tests/test_results*'
-           }
-           script {
-           sh """
-              docker stop polycubed || true
-              docker system prune --all --force
-           """
-           }
-           sh 'rm -rf ${WORKSPACE}/*'
-        }
-        failure {
-          script {
-            setGithubStatus("${commit_id}", "error", github_token, "polycube-network/polycube", "Clean Instance Tests", "Clean Instance Tests")
-          }
-        }
-        unstable {
-          script {
-            setGithubStatus("${commit_id}", "failure", github_token, "polycube-network/polycube", "Clean Instance Tests", "Clean Instance Tests")
-          }
-        }
-        success {
-          script {
-           setGithubStatus("${commit_id}", "success", github_token, "polycube-network/polycube", "Clean Instance Tests", "Clean Instance Tests")
-          }
-        }
-       }
-      }
-    stage('Launch Same Instance Tests') {
-           agent {
-                    label "docker && testing-2"
-              }
-              steps {
-               script {
-                 docker.withRegistry("", 'polycube-repo') {
-                  sh"""
-                  set +e
-                  docker run -d --name polycubed --rm --privileged --network host -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -v /etc/localtime:/etc/localtime:ro             polycubebot/${image_name}-default:${image_tag}
-                  mkdir bin
-                  docker cp polycubed:/usr/local/bin/polycubectl ./bin/
-                  export PATH=$PATH:${WORKSPACE}/bin
-                  export KILL_COMMAND="docker stop polycubed"
-                  export polycubed="docker run -d --name polycubed --rm --privileged --network host -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -v /etc/localtime:/etc/localtime:ro polycubebot/${image_name}-default:${image_tag}"
-                  cd tests/ && ./run-tests.sh false || true
-                  export LC_ALL=C
-                  virtualenv venv -p python3
-                  . venv/bin/activate
-                  pip install -r converter/requirements.txt
-                  export TEST_RESULTS=`ls -1 test_results_*`
-                  python3 converter/to_junit.py SameInstance
-                  """
-                   }
-                   }
-                   }
-       post {
-        always {
-           script {
-           dir(".") {
-                junit allowEmptyResults: true, testResults: "tests/output.xml"
-                archiveArtifacts artifacts: 'tests/test_results*'
-           }
-           sh """
-              docker stop polycubed || true
-              docker system prune --all --force
-           """
-           }
-           sh 'rm -rf ${WORKSPACE}/*'
-        }
-        failure {
-          script {
-            setGithubStatus("${commit_id}", "error", github_token, "polycube-network/polycube", "Same Instance Tests", "Same Instance Tests")
-          }
-        }
-        unstable {
-          script {
-            setGithubStatus("${commit_id}", "failure", github_token, "polycube-network/polycube", "Same Instance Tests", "Same Instance Tests")
-          }
-        }
-        success {
-          script {
-           setGithubStatus("${commit_id}", "success", github_token, "polycube-network/polycube", "Same Instance Tests", "Same Instance Tests")
-          }
-        }
-       }
-      }
-    stage('Launch Iptables Tests') {
-           agent {
-                    label "docker && pcn-iptables"
-              }
-              steps {
-               script {
-        docker.withRegistry("", 'polycube-repo') {
-                  sh"""
-                  set +e
-                  docker run -d --name polycubed --rm --privileged --network host -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -v /etc/localtime:/etc/localtime:ro             polycubebot/${image_name}-pcn-iptables:${image_tag}
-                  mkdir bin
-                  docker cp polycubed:/usr/local/bin/polycubectl ./bin/
-                  export PATH=$PATH:${WORKSPACE}/bin
-                  export KILL_COMMAND="docker stop polycubed"
-                  export polycubed="docker run -d --name polycubed --rm --privileged --network host -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -v /etc/localtime:/etc/localtime:ro             polycubebot/${image_name}-pcn-iptables:${image_tag}"
-                  cd tests/
-                  ./run-tests-iptables.sh || true
-                  export LC_ALL=C
-                  virtualenv venv -p python3
-                  . venv/bin/activate
-                  pip install -r converter/requirements.txt
-                  export TEST_RESULTS=`ls -1 test_results_*`
-                  python3 converter/to_junit.py Iptables
-                  """
-                   }
-                   }
-                   }
-       post {
-        always {
-           dir(".") {
-                junit allowEmptyResults: true, testResults: "tests/output.xml"
-                archiveArtifacts artifacts: 'tests/test_results*'
-           }
-           script {
-           sh """
-              docker stop polycubed || true
-              docker system prune --all --force
-           """
-           }
-           sh 'rm -rf ${WORKSPACE}/*'
-        }
-       failure {
-          script {
-            setGithubStatus("${commit_id}", "error", github_token, "polycube-network/polycube", "Iptables Tests", "Iptables Tests")
-          }
-        }
-       unstable {
-          script {
-            setGithubStatus("${commit_id}", "failure", github_token, "polycube-network/polycube", "Iptables Tests", "Iptables Tests")
-          }
-        }
-        success {
-          script {
-           setGithubStatus("${commit_id}", "success", github_token, "polycube-network/polycube", "Iptables Tests", "Iptables Tests")
-          }
-        }
-       }
-       }
-       }
-      }
-    stage("Promote Images") {
-       when {
-          branch 'master'
-       }
-       agent {
-          label "docker"
-       }
-       steps {
-       script {
-        docker.withRegistry("", 'polycube-repo') {
-        sh """export DOCKER_BUILDKIT=1
-        docker pull "polycubebot/${image_name}-default:${image_tag}"
-        docker tag "polycubebot/${image_name}-default:${image_tag}" "polycube-network/polycube:latest"
-        docker push "polycube-network/polycube:latest"
-        docker pull "polycubebot/${image_name}-pcn-k8s:${image_tag}"
-        docker tag "polycubebot/${image_name}-pcn-k8s:${image_tag}" "polycube-network/k8s-pod-network:latest"
-        docker push "polycube-network/k8s-pod-network:latest"
-        docker system prune --all --force
-        """
-        }
-    }
-    }
-    }
-    }
-     post {
-                always {
-                      slackNotification(currentBuild.result,notification_url,"Polycube")
-                      sh 'rm -rf ${WORKSPACE}/*'
-
+        stage('Build Base Image') {
+            when {
+                triggeredBy 'TimerTrigger'
+            }
+            agent {
+                label "docker"
+            }
+            steps {
+                script {
+                    docker.withRegistry("", 'polycube-repo') {
+                        sh """
+                            export DOCKER_BUILDKIT=1
+                            docker system prune --all --force
+                            docker build . -t "polycubebot/base_image:${image_tag}" -f Dockerfile_base_image
+                            docker tag polycubebot/base_image:${image_tag} polycubebot/base_image:latest
+                            docker push polycubebot/base_image:${image_tag}
+                            docker push polycubebot/base_image:latest
+                        """
                     }
                 }
             }
-
-
+            post {
+                failure {
+                    script {
+                        setGithubStatus("${commit_id}", "pending", github_token, "polycube-network/polycube", "Docker Image Build", "Docker Image Build")
+                    }
+                }
+            }
+        }
+        stage('Parallel Docker Build') {
+            parallel {
+                stage("Build Docker Mode: default") {
+                    agent {
+                        label "docker"
+                    }
+                    steps {
+                        script {
+                            docker.withRegistry("", 'polycube-repo') {
+                                sh """
+                                    export DOCKER_BUILDKIT=1
+                                    docker system prune --all --force
+                                    # checking if the latest pushed image has the same tag of the current image_tag
+                                    if wget -qO- https://hub.docker.com/v2/repositories/polycubebot/${image_name}-default/tags/ | jq -r '.["results"][]["name"]' | grep -q ${image_tag}
+                                    then
+                                        echo "image ${image_name}-default already pushed with tag ${image_tag}"
+                                        echo "skipping image building"
+                                    else
+                                        docker build . -t "polycubebot/${image_name}-default:${image_tag}" --build-arg DEFAULT_MODE=default
+                                        docker push polycubebot/${image_name}-default:${image_tag}
+                                    fi
+                                """
+                            }
+                        }
+                    }
+                }
+                stage("Build Docker Mode: pcn-k8s") {
+                    agent {
+                        label "docker"
+                    }
+                    steps {
+                        script {
+                            docker.withRegistry("", 'polycube-repo') {
+                                sh """
+                                    export DOCKER_BUILDKIT=1
+                                    docker system prune --all --force
+                                    # checking if the latest pushed image has the same tag of the current image_tag
+                                    if wget -qO- https://hub.docker.com/v2/repositories/polycubebot/${image_name}-pcn-k8s/tags/ | jq -r '.["results"][]["name"]' | grep -q ${image_tag}
+                                    then
+                                        echo "image ${image_name}-pcn-k8s already pushed with tag ${image_tag}"
+                                        echo "skipping image building"
+                                    else
+                                        docker build . -t "polycubebot/${image_name}-pcn-k8s:${image_tag}" --build-arg DEFAULT_MODE=pcn-k8s
+                                        docker push polycubebot/${image_name}-pcn-k8s:${image_tag}
+                                    fi
+                                """
+                            }
+                        }
+                    }
+                }
+                stage("Build Docker Mode: pcn-iptables") {
+                    agent {
+                        label "docker"
+                    }
+                    steps {
+                        script {
+                            docker.withRegistry("", 'polycube-repo') {
+                                sh """
+                                    export DOCKER_BUILDKIT=1
+                                    docker system prune --all --force
+                                    # checking if the latest pushed image has the same tag of the current image_tag
+                                    if wget -qO- https://hub.docker.com/v2/repositories/polycubebot/${image_name}-pcn-iptables/tags/ | jq -r '.["results"][]["name"]' | grep -q ${image_tag}
+                                    then
+                                        echo "image ${image_name}-pcn-iptables already pushed with tag ${image_tag}"
+                                        echo "skipping image building"
+                                    else
+                                        docker build . -t "polycubebot/${image_name}-pcn-iptables:${image_tag}" --build-arg DEFAULT_MODE=pcn-iptables
+                                        docker push polycubebot/${image_name}-pcn-iptables:${image_tag}
+                                    fi
+                                """
+                            }
+                        }
+                    }
+                }
+            }
+            post {
+                failure {
+                    script {
+                        setGithubStatus("${commit_id}", "failure", github_token, "polycube-network/polycube", "Docker Image Build", "Docker Image Build")
+                    }
+                }
+                success {
+                    script {
+                        setGithubStatus("${commit_id}", "success", github_token, "polycube-network/polycube", "Docker Image Build", "Docker Image Build")
+                    }
+                }
+            }
+        }
+        stage('Testing') {
+            parallel {
+                stage('Launch Clean Instance Tests') {
+                    agent {
+                        label "docker"
+                    }
+                    steps {
+                        script {
+                            docker.withRegistry("", 'polycube-repo') {
+                                sh """
+                                    docker stop polycubed || true
+                                    docker system prune --all --force
+                                    # Launch the polycubed daemon and extract the polycubectl
+                                    # /proc is mounted under /host/proc to have a complete visibility of the namespaces created outside of the container
+                                    docker run -d --name polycubed --rm --privileged --pid=host --cap-add ALL --network host -v /proc:/host/proc -v /lib/modules:/lib/modules:ro -v /var/run/netns/:/var/run/netns:rw -v /usr/src:/usr/src:ro -v /etc/localtime:/etc/localtime:ro polycubebot/${image_name}-default:${image_tag}
+                                    mkdir bin
+                                    docker cp polycubed:/usr/local/bin/polycubectl ./bin/
+                                    # Overload environment variables in order to adapt the behavior of run_tests script
+                                    export PATH=$PATH:${WORKSPACE}/bin
+                                    export KILL_COMMAND="docker stop polycubed"
+                                    export polycubed="docker run -d --name polycubed --rm --privileged --pid=host --cap-add ALL --network host -v /lib/modules:/lib/modules:ro -v /proc:/host/proc -v /var/run/netns/:/var/run/netns:rw -v /usr/src:/usr/src:ro -v /etc/localtime:/etc/localtime:ro polycubebot/${image_name}-default:${image_tag}"
+                                    # Killing polycube image if running
+                                    \$KILL_COMMAND
+                                    cd tests/
+                                    # For the moment, tests always returns 0 to enable junit generation
+                                    ./run-tests.sh || true
+                                    export LC_ALL=C
+                                    virtualenv venv -p python3
+                                    . venv/bin/activate
+                                    pip install -r converter/requirements.txt
+                                    export TEST_RESULTS=`ls -1 test_results_*`
+                                    python3 converter/to_junit.py CleanInstance
+                                """
+                            }
+                            }
+                    }
+                    post {
+                        always {
+                            dir(".") {
+                                junit allowEmptyResults: true, testResults: "tests/output.xml"
+                                archiveArtifacts artifacts: 'tests/test_results*'
+                            }
+                            script {
+                                sh """
+                                    docker stop polycubed || true
+                                    docker system prune --all --force
+                                """
+                            }
+                            sh 'rm -rf ${WORKSPACE}/*'
+                        }
+                        failure {
+                            script {
+                                setGithubStatus("${commit_id}", "error", github_token, "polycube-network/polycube", "Clean Instance Tests", "Clean Instance Tests")
+                            }
+                        }
+                        unstable {
+                            script {
+                                setGithubStatus("${commit_id}", "failure", github_token, "polycube-network/polycube", "Clean Instance Tests", "Clean Instance Tests")
+                            }
+                        }
+                        success {
+                            script {
+                                setGithubStatus("${commit_id}", "success", github_token, "polycube-network/polycube", "Clean Instance Tests", "Clean Instance Tests")
+                            }
+                        }
+                    }
+                }
+                stage('Launch Same Instance Tests') {
+                    agent {
+                        label "docker"
+                    }
+                    steps {
+                        script {
+                            docker.withRegistry("", 'polycube-repo') {
+                                sh """
+                                    docker stop polycubed || true
+                                    docker system prune --all --force
+                                    set +e
+                                    docker run -d --name polycubed --rm --privileged --pid=host --cap-add ALL --network host -v /proc:/host/proc -v /lib/modules:/lib/modules:ro -v /var/run/netns/:/var/run/netns:rw -v /usr/src:/usr/src:ro -v /etc/localtime:/etc/localtime:ro polycubebot/${image_name}-default:${image_tag}
+                                    mkdir bin
+                                    docker cp polycubed:/usr/local/bin/polycubectl ./bin/
+                                    export PATH=$PATH:${WORKSPACE}/bin
+                                    export KILL_COMMAND="docker stop polycubed"
+                                    export polycubed="docker run -d --name polycubed --rm --privileged --pid=host --cap-add ALL --network host -v /lib/modules:/lib/modules:ro -v /proc:/host/proc -v /var/run/netns/:/var/run/netns:rw -v /usr/src:/usr/src:ro -v /etc/localtime:/etc/localtime:ro polycubebot/${image_name}-default:${image_tag}"
+                                    cd tests/ && ./run-tests.sh false || true
+                                    export LC_ALL=C
+                                    virtualenv venv -p python3
+                                    . venv/bin/activate
+                                    pip install -r converter/requirements.txt
+                                    export TEST_RESULTS=`ls -1 test_results_*`
+                                    python3 converter/to_junit.py SameInstance
+                                """
+                            }
+                        }
+                    }
+                    post {
+                        always {
+                            script {
+                                dir(".") {
+                                    junit allowEmptyResults: true, testResults: "tests/output.xml"
+                                    archiveArtifacts artifacts: 'tests/test_results*'
+                                }
+                                sh """
+                                    docker stop polycubed || true
+                                    docker system prune --all --force
+                                """
+                            }
+                            sh 'rm -rf ${WORKSPACE}/*'
+                        }
+                        failure {
+                            script {
+                                setGithubStatus("${commit_id}", "error", github_token, "polycube-network/polycube", "Same Instance Tests", "Same Instance Tests")
+                            }
+                        }
+                        unstable {
+                            script {
+                                setGithubStatus("${commit_id}", "failure", github_token, "polycube-network/polycube", "Same Instance Tests", "Same Instance Tests")
+                            }
+                        }
+                        success {
+                            script {
+                                setGithubStatus("${commit_id}", "success", github_token, "polycube-network/polycube", "Same Instance Tests", "Same Instance Tests")
+                            }
+                        }
+                    }
+                }
+                stage('Launch Iptables Tests') {
+                    agent {
+                        label "docker"
+                    }
+                    steps {
+                        script {
+                            docker.withRegistry("", 'polycube-repo') {
+                                sh """
+                                    docker stop polycubed || true
+                                    docker system prune --all --force
+                                    set +e
+                                    docker run -d --name polycubed --rm --privileged --pid=host --cap-add ALL --network host -v /proc:/host/proc -v /lib/modules:/lib/modules:ro -v /var/run/netns/:/var/run/netns:rw -v /usr/src:/usr/src:ro -v /etc/localtime:/etc/localtime:ro polycubebot/${image_name}-pcn-iptables:${image_tag}
+                                    mkdir bin
+                                    docker cp polycubed:/usr/local/bin/polycubectl ./bin/
+                                    export PATH=$PATH:${WORKSPACE}/bin
+                                    export KILL_COMMAND="docker stop polycubed"
+                                    export polycubed="docker run -d --name polycubed --rm --privileged --pid=host --cap-add ALL --network host -v /lib/modules:/lib/modules:ro -v /proc:/host/proc -v /var/run/netns/:/var/run/netns:rw -v /usr/src:/usr/src:ro -v /etc/localtime:/etc/localtime:ro polycubebot/${image_name}-pcn-iptables:${image_tag}"
+                                    cd tests/ && ./run-tests-iptables.sh || true
+                                    export LC_ALL=C
+                                    virtualenv venv -p python3
+                                    . venv/bin/activate
+                                    pip install -r converter/requirements.txt
+                                    export TEST_RESULTS=`ls -1 test_results_*`
+                                    python3 converter/to_junit.py Iptables
+                                """
+                            }
+                        }
+                    }
+                    post {
+                        always {
+                            dir(".") {
+                                junit allowEmptyResults: true, testResults: "tests/output.xml"
+                                archiveArtifacts artifacts: 'tests/test_results*'
+                            }
+                            script {
+                                sh """
+                                    docker stop polycubed || true
+                                    docker system prune --all --force
+                                """
+                            }
+                            sh 'rm -rf ${WORKSPACE}/*'
+                        }
+                        failure {
+                            script {
+                                setGithubStatus("${commit_id}", "error", github_token, "polycube-network/polycube", "Iptables Tests", "Iptables Tests")
+                            }
+                        }
+                        unstable {
+                            script {
+                                setGithubStatus("${commit_id}", "failure", github_token, "polycube-network/polycube", "Iptables Tests", "Iptables Tests")
+                            }
+                        }
+                        success {
+                            script {
+                                setGithubStatus("${commit_id}", "success", github_token, "polycube-network/polycube", "Iptables Tests", "Iptables Tests")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage("Promote Images") {
+            when {
+                branch 'master'
+            }
+            agent {
+                label "docker"
+            }
+            steps {
+                script {
+                    docker.withRegistry("", 'polycube-repo') {
+                        sh """
+                            export DOCKER_BUILDKIT=1
+                            docker pull "polycubebot/${image_name}-default:${image_tag}"
+                            docker tag "polycubebot/${image_name}-default:${image_tag}" "polycubenetwork/polycube:latest"
+                            docker push "polycubenetwork/polycube:latest"
+                            docker pull "polycubebot/${image_name}-pcn-k8s:${image_tag}"
+                            docker tag "polycubebot/${image_name}-pcn-k8s:${image_tag}" "polycubenetwork/k8s-pod-network:latest"
+                            docker push "polycubenetwork/k8s-pod-network:latest"
+                            docker system prune --all --force
+                        """
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            slackNotification(currentBuild.result,notification_url,"Polycube")
+            sh 'rm -rf ${WORKSPACE}/*'
+        }
+    }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,5 @@ ADD src/components/k8s/cni/cni-uninstall.sh /cni-uninstall.sh
 ADD src/components/k8s/pcn_k8s/cleanup.sh /cleanup.sh
 ADD src/components/k8s/pcn_k8s/init.sh /init.sh
 
-CMD ["polycubed"]
+# by running nsenter --mount=/host/proc/1/ns/mnt polycubed, the daemon has a complete view of the namespaces of the host and it is able to manipulate them (needed for shadow services)
+CMD ["nsenter","--mount=/host/proc/1/ns/mnt","polycubed"]

--- a/src/services/pcn-nat/test/test_tcp_snat.sh
+++ b/src/services/pcn-nat/test/test_tcp_snat.sh
@@ -16,9 +16,9 @@ source "${BASH_SOURCE%/*}/helpers.bash"
 
 function test_tcp {
     sudo ip netns exec ns2 netcat -l -w 5 $tcp_port&
-	sleep 2
+	sleep 5
 	sudo ip netns exec ns1 netcat -w 2 -nvz $veth2_ip $tcp_port
-	sleep 4
+	sleep 5
 }
 
 function cleanup {

--- a/src/services/pcn-pbforwarder/test/test2_10.sh
+++ b/src/services/pcn-pbforwarder/test/test2_10.sh
@@ -2,7 +2,7 @@
 
 source "${BASH_SOURCE%/*}/helpers.bash"
 
-function pbfeanup {
+function pbfeanup() {
   set +e
   del_pbforwarders 1
   del_veths 2

--- a/tests/helpers_tests.bash
+++ b/tests/helpers_tests.bash
@@ -3,8 +3,15 @@
 # cleanup environment before exit
 function cleanup {
   set +e
+  
   echo "killing polycubed ..."
-  sudo pkill polycubed >> $test_tmp
+  if [ -z "$KILL_COMMAND" ]
+  then
+      sudo pkill polycubed >> $test_tmp
+  else
+      `$KILL_COMMAND` >> $test_tmp
+  fi
+
   echo "{ \"passed\":\"$test_passed\", \"total\":\"$test_total\", \"test_log\":\"$test_log\" }" > $RESULT_JSON
 
   cat $test_results


### PR DESCRIPTION
Docker base image is now built only triggered by a `cron` at 2:00 am (everyday) to reduce the building time of the pipeline.
Mounting volumes of the polycubed image have been changed:
- `/proc` is now mounted under `/host/proc` to have a complete visibility of the namespaces created outside of the container.

Solving iptables tests:
Docker manipulates the iptables policy of the node during his installation and this makes the kernel drop the packets forwarded between different network namespaces; to solve this, `sudo iptables -P FORWARD ACCEPT` must be run on the host before running tests in order avoid the kernel drops packets.