### PR TITLE
fix pcn-k8s docker build document

### DIFF
--- a/Documentation/components/k8s/developers.rst
+++ b/Documentation/components/k8s/developers.rst
@@ -8,6 +8,7 @@ Docker 18.06 is needed to build the images, and the daemon has to be started wit
 `See this issue to have more information <https://github.com/moby/moby/issues/32507>`_.
 
 ::
+
     export DOCKER_BUILDKIT=1 # flag needed to enable the --mount option
-    docker build --build-arg MODE=pcn-k8s -t name:tag .
+    docker build --build-arg DEFAULT_MODE=pcn-k8s -t name:tag .
     docker push name:tag


### PR DESCRIPTION
- add extra line to make literal code block display appropriately
- fix the docker build parameter, pcn-k8s should be passed to docker as argument
  instead of environment