### PR TITLE
fix docker file issue 

### DIFF
--- a/Dockerfile_base_image
+++ b/Dockerfile_base_image
@@ -1,7 +1,7 @@
 # syntax = tonistiigi/dockerfile:runmount20180618
 FROM ubuntu:18.04
-RUN --mount=target=/polycube cp -r /polycube /tmp/polycube && \
-cd /tmp/polycube && \
-SUDO="" WORKDIR="/tmp/dev" \
+COPY scripts/pre-requirements.sh /tmp/
+RUN cd /tmp/ && \
 apt update && \
-./scripts/pre-requirements.sh
+SUDO="" WORKDIR="/tmp/dev" ./pre-requirements.sh && \
+rm -f /tmp/pre-requirements.sh

--- a/scripts/pre-requirements.sh
+++ b/scripts/pre-requirements.sh
@@ -5,7 +5,7 @@ then
 fi
 mkdir -p $WORKDIR
 
-$SUDO sudo apt update
+$SUDO apt update
 $SUDO bash -c "apt install --allow-unauthenticated -y wget gnupg2 software-properties-common"
 
 # golang v1.12 still not available in repos


### PR DESCRIPTION
the docker image is built against the /tmp/polycube directory which is copied from the latest source code, but in the based image the /tmp/polycube is already existing. In the case the based image is not the latest code then the docker image doesn't contains the latest code. 

This PR make a clean sandbox before copying and building the docker image against the source code, otherwise the docker image could be built against the old sandbox left-over in the base image. Another way to do that is to clean the base image /tmp/polycube directory but anyway make a clean sandbox is always a good habit without any assumption.