### PR TITLE
Adding Clean Directory and Checkout + after-tests namespaces cleaning

### DIFF
--- a/CI/JenkinsfileTestCleanInstance
+++ b/CI/JenkinsfileTestCleanInstance
@@ -31,7 +31,6 @@ def slackNotification(buildStatus,String notification_url = "",project_name = ""
             ]
         ]
     )
-
     sh "curl -X POST --fail -H 'Content-type: application/json' --data '${payload}' ${notification_url}"
 }
 
@@ -87,6 +86,14 @@ pipeline {
                     setGithubStatus("${commit_id}", "pending", github_token, "polycube-network/polycube", "Docker Image Build", "Docker Image Build")
                     slackNotification("STARTED",notification_url,"Polycube")
                 }
+            }
+        }
+        stage ('Clean Directory and Checkout') {
+            steps {
+                dir('.') {
+                    deleteDir()
+                }
+                checkout scm
             }
         }
         stage('Build Base Image') {

--- a/CI/clean_slave.sh
+++ b/CI/clean_slave.sh
@@ -30,3 +30,7 @@ for lib in $(ls /lib/x86_64-linux-gnu/ | grep -P "libnl"); do
     sudo rm -rf /lib/x86_64-linux-gnu/$lib
 done
 sudo ldconfig
+for namespace in $(ls /var/run/netns/ | grep -Po "ns[0-9]"); do
+    echo "removing namespace $namespace"
+    sudo ip netns del $namespace
+done


### PR DESCRIPTION
This PR adds a Stage that clears the working directory of the slaves before building the docker images
and looks for non-deleted namespaces left by tests and delete them.