### PR TITLE
Generate polycubectl config directory with traverse permission

### DIFF
--- a/src/polycubectl/config/config.go
+++ b/src/polycubectl/config/config.go
@@ -85,6 +85,9 @@ func saveConfig(config Config) error {
 		return fmt.Errorf("error during json Marshal: %s", err.Error())
 	}
 
+	// Create a directory for the config file with read, write and execute
+	// permission for the current user (700)
+	// (both w and x are needed to edit the content of the dir)
 	os.MkdirAll(home+PathToConfigFile, 0700)
 
 	f, err := os.Create(home + PathToConfigFile + ConfigFile)

--- a/src/polycubectl/config/config.go
+++ b/src/polycubectl/config/config.go
@@ -85,7 +85,7 @@ func saveConfig(config Config) error {
 		return fmt.Errorf("error during json Marshal: %s", err.Error())
 	}
 
-	os.MkdirAll(home+PathToConfigFile, 0600)
+	os.MkdirAll(home+PathToConfigFile, 0700)
 
 	f, err := os.Create(home + PathToConfigFile + ConfigFile)
 	defer f.Close()


### PR DESCRIPTION
polycubectl creates a folder without traverse permission to contain the config file.
This causes the subsequent file generation to fail.
This PR fixes the problem.