### PR TITLE
fix polycubed crash & add a CLI to check the cubes given a interface

### DIFF
--- a/src/polycubed/src/extiface.h
+++ b/src/polycubed/src/extiface.h
@@ -66,6 +66,9 @@ class ExtIface : public PeerIface {
   std::string get_parameter(const std::string &param_name) override;
   void set_parameter(const std::string &param_name,
                      const std::string &value) override;
+  uint16_t get_next(ProgramType type);
+  TransparentCube* get_next_cube(ProgramType type);
+  std::vector<std::string> get_service_chain(ProgramType type);
 
  protected:
   // 2 maps: one for IP events and one for MAC events

--- a/src/polycubed/src/extiface.h
+++ b/src/polycubed/src/extiface.h
@@ -41,6 +41,13 @@ class ExtIface : public PeerIface {
   ExtIface(const ExtIface &) = delete;
   ExtIface &operator=(const ExtIface &) = delete;
 
+  /* return ExtIface pointer given interface name
+   * or return null if
+   * - either the interface name doesn't exist
+   * - or no extiface created for the interface name
+   */
+  static ExtIface* get_extiface(const std::string &iface_name);
+
   uint16_t get_index() const override;
   uint16_t get_port_id() const override;
   void set_peer_iface(PeerIface *peer) override;
@@ -71,7 +78,7 @@ class ExtIface : public PeerIface {
 
   std::mutex event_mutex;
 
-  static std::set<std::string> used_ifaces;
+  static std::map<std::string, ExtIface*> used_ifaces;
   int load_ingress();
   int load_egress();
   int load_tx();
@@ -82,7 +89,6 @@ class ExtIface : public PeerIface {
   virtual bpf_prog_type get_program_type() const = 0;
 
   void update_indexes() override;
-  int calculate_cube_index(int index) override;
 
   ebpf::BPF ingress_program_;
   ebpf::BPF egress_program_;

--- a/src/polycubed/src/peer_iface.cpp
+++ b/src/polycubed/src/peer_iface.cpp
@@ -124,6 +124,32 @@ std::vector<std::string> PeerIface::get_cubes_names() const {
   return cubes_names;
 }
 
+std::vector<uint16_t> PeerIface::get_cubes_ingress_index() const {
+  std::lock_guard<std::mutex> guard(mutex_);
+
+  std::vector<uint16_t> ingress_indices;
+
+  for (auto &cube : cubes_) {
+      ingress_indices.push_back(cube->get_index(ProgramType::INGRESS));
+  }
+
+  return ingress_indices;
+}
+
+std::vector<uint16_t> PeerIface::get_cubes_egress_index() const {
+  std::lock_guard<std::mutex> guard(mutex_);
+
+  std::vector<uint16_t> egress_indices;
+
+  for (auto &cube : cubes_) {
+      egress_indices.push_back(cube->get_index(ProgramType::EGRESS));
+  }
+
+  return egress_indices;
+}
+
+
+
 PeerIface::CubePositionComparison PeerIface::compare_position(
     const std::string &cube1, const std::string &cube2) {
   // cube position, index 0 is the innermost one

--- a/src/polycubed/src/peer_iface.h
+++ b/src/polycubed/src/peer_iface.h
@@ -52,6 +52,8 @@ class PeerIface {
                const std::string &other);
   void remove_cube(const std::string &type);
   std::vector<std::string> get_cubes_names() const;
+  std::vector<uint16_t> get_cubes_ingress_index() const;
+  std::vector<uint16_t> get_cubes_egress_index() const;
 
  protected:
   enum class CubePositionComparison {

--- a/src/polycubed/src/polycubed_core.cpp
+++ b/src/polycubed/src/polycubed_core.cpp
@@ -213,7 +213,35 @@ std::string PolycubedCore::get_if_topology(const std::string &if_name) {
 
    auto extIface = polycube::polycubed::ExtIface::get_extiface(if_name);
    if (extIface != NULL) {
-       j["cubes"] = extIface->get_cubes_names();
+       auto names = extIface->get_cubes_names();
+       auto ingress_indices = extIface->get_cubes_ingress_index();
+       auto egress_indices = extIface->get_cubes_egress_index();
+       std::vector<std::string> cubes_info;
+       std::ostringstream stream;
+       for (int i=0; i<names.size(); i++) {
+           stream.str("");
+           stream << names[i] << ",\t" << ingress_indices[i] << ",\t" << egress_indices[i];
+           cubes_info.push_back(std::string(stream.str()));
+       }
+       j["cubes, ingress_index, egress_index"] = cubes_info;
+
+       stream.str("");
+       auto i_serv_chain = extIface->get_service_chain(ProgramType::INGRESS);
+       for (auto service : i_serv_chain) {
+           stream << service;
+           if (service != std::string("stack"))
+               stream << " ---> ";
+       }
+       j["ingress service chain"] = stream.str();
+
+       stream.str("");
+       auto e_serv_chain = extIface->get_service_chain(ProgramType::EGRESS);
+       for (auto service : e_serv_chain) {
+           stream << service;
+           if (service != std::string("stack"))
+               stream << " ---> ";
+       }
+       j["egress service chain"] = stream.str();
    }
    return j.dump(4);
 }

--- a/src/polycubed/src/polycubed_core.cpp
+++ b/src/polycubed/src/polycubed_core.cpp
@@ -208,6 +208,16 @@ std::string PolycubedCore::topology() {
   return j.dump(4);
 }
 
+std::string PolycubedCore::get_if_topology(const std::string &if_name) {
+   json j = {{"name", if_name}};
+
+   auto extIface = polycube::polycubed::ExtIface::get_extiface(if_name);
+   if (extIface != NULL) {
+       j["cubes"] = extIface->get_cubes_names();
+   }
+   return j.dump(4);
+}
+
 std::string get_port_peer(const std::string &port) {
   std::smatch match;
   std::regex rule("(\\S+):(\\S+)");

--- a/src/polycubed/src/polycubed_core.h
+++ b/src/polycubed/src/polycubed_core.h
@@ -64,6 +64,7 @@ class PolycubedCore {
   std::string get_netdevs();
 
   std::string topology();
+  std::string get_if_topology(const std::string &if_name);
 
   void connect(const std::string &peer1, const std::string &peer2);
   void disconnect(const std::string &peer1, const std::string &peer2);

--- a/src/polycubed/src/rest_server.cpp
+++ b/src/polycubed/src/rest_server.cpp
@@ -271,6 +271,8 @@ void RestServer::setup_routes() {
   // topology
   router_->get(base + std::string("/topology"),
                bind(&RestServer::topology, this));
+  router_->get(base + std::string("/topology/:ifname"),
+               bind(&RestServer::get_if_topology, this));
 
   router_->options(base + std::string("/topology"),
                    bind(&RestServer::topology_help, this));
@@ -827,6 +829,19 @@ void RestServer::topology(const Pistache::Rest::Request &request,
   } catch (const std::runtime_error &e) {
     logger->error("{0}", e.what());
     response.send(Pistache::Http::Code::Bad_Request, e.what());
+  }
+}
+
+void RestServer::get_if_topology(const Pistache::Rest::Request &request,
+                                Pistache::Http::ResponseWriter response) {
+  logRequest(request);
+  try {
+      auto ifname = request.param(":ifname").as<std::string>();
+      std::string retJsonStr = core.get_if_topology(ifname);
+      response.send(Pistache::Http::Code::Ok, retJsonStr);
+  } catch (const std::runtime_error &e) {
+      logger->error("{0}", e.what());
+      response.send(Pistache::Http::Code::Bad_Request, e.what());
   }
 }
 

--- a/src/polycubed/src/rest_server.h
+++ b/src/polycubed/src/rest_server.h
@@ -122,6 +122,8 @@ class RestServer {
               Pistache::Http::ResponseWriter response);
   void topology(const Pistache::Rest::Request &request,
                 Pistache::Http::ResponseWriter response);
+  void get_if_topology(const Pistache::Rest::Request &request,
+                Pistache::Http::ResponseWriter response);
   void topology_help(const Pistache::Rest::Request &request,
                      Pistache::Http::ResponseWriter response);
 

--- a/src/polycubed/src/transparent_cube.cpp
+++ b/src/polycubed/src/transparent_cube.cpp
@@ -71,6 +71,10 @@ void TransparentCube::set_next(uint16_t next, ProgramType type) {
   reload_all();
 }
 
+uint16_t TransparentCube::get_next(ProgramType type) {
+  return type == ProgramType::INGRESS ? ingress_next_ : egress_next_;
+}
+
 void TransparentCube::set_parent(PeerIface *parent) {
   parent_ = parent;
   if (parent_) {

--- a/src/polycubed/src/transparent_cube.h
+++ b/src/polycubed/src/transparent_cube.h
@@ -36,6 +36,7 @@ class TransparentCube : public BaseCube, public TransparentCubeIface {
   virtual ~TransparentCube();
 
   void set_next(uint16_t next, ProgramType type);
+  uint16_t get_next(ProgramType type);
   void set_parent(PeerIface *parent);
   PeerIface *get_parent();
   void set_parameter(const std::string &parameter, const std::string &value);

--- a/tests/transparent_services/test_service_chain.sh
+++ b/tests/transparent_services/test_service_chain.sh
@@ -1,0 +1,63 @@
+#! /bin/bash
+
+# check that the services are actually transverse on the right order
+
+source "${BASH_SOURCE%/*}/../helpers.bash"
+
+set -e
+set -x
+
+function cleanup {
+  set +e
+  polycubectl del th1
+  polycubectl del th2
+  polycubectl del th3
+  polycubectl del th4
+  polycubectl del th5
+  delete_veth 1
+  echo "FAIL"
+}
+trap cleanup EXIT
+
+create_veth 1
+
+polycubectl transparenthelloworld add th1 loglevel=TRACE
+polycubectl transparenthelloworld add th2 loglevel=TRACE
+polycubectl transparenthelloworld add th3 loglevel=TRACE
+polycubectl transparenthelloworld add th4 loglevel=TRACE
+polycubectl transparenthelloworld add th5 loglevel=TRACE
+
+polycubectl attach th3 veth1
+polycubectl attach th1 veth1 position=first
+polycubectl attach th5 veth1 position=last
+polycubectl attach th2 veth1 after=th1
+polycubectl attach th4 veth1 before=th5
+
+# verfiy the service chain order
+polycubectl topology show veth1 | egrep "ingress service chain: th1 ---> th2 ---> th3 ---> th4 ---> th5 ---> stack"
+polycubectl topology show veth1 | egrep "egress service chain: th5 ---> th4 ---> th3 ---> th2 ---> th1 ---> stack"
+
+# sudo ip netns exec ns1 ping 10.0.0.2 -c 1
+
+#TODO: verify the log output, expected log output
+#[2019-12-06 11:39:20.512] [Transparenthelloworld] [th1] [debug] Ingress: passing packet
+#[2019-12-06 11:39:20.512] [Transparenthelloworld] [th2] [debug] Ingress: passing packet
+#[2019-12-06 11:39:20.512] [Transparenthelloworld] [th3] [debug] Ingress: passing packet
+#[2019-12-06 11:39:20.512] [Transparenthelloworld] [th4] [debug] Ingress: passing packet
+#[2019-12-06 11:39:20.512] [Transparenthelloworld] [th5] [debug] Ingress: passing packet
+#[2019-12-06 11:39:20.512] [Transparenthelloworld] [th5] [debug] Egress: passing packet
+#[2019-12-06 11:39:20.512] [Transparenthelloworld] [th4] [debug] Egress: passing packet
+#[2019-12-06 11:39:20.512] [Transparenthelloworld] [th3] [debug] Egress: passing packet
+#[2019-12-06 11:39:20.512] [Transparenthelloworld] [th2] [debug] Egress: passing packet
+#[2019-12-06 11:39:20.512] [Transparenthelloworld] [th1] [debug] Egress: passing packet
+
+polycubectl del th1
+polycubectl del th2
+polycubectl del th3
+polycubectl del th4
+polycubectl del th5
+delete_veth 1
+
+set +x
+trap - EXIT
+echo "SUCCESS"


### PR DESCRIPTION
When attach multiple cubes to one interface with "position=last", "before=xxx", "after=xxx", system crashes. This PR fixes the crashing issue and add a CLI to check the cubes attaches to a interface given a name.