### PR TITLE
A new elegant whiptail based documentation script for polycube

### DIFF
--- a/scripts/man.sh
+++ b/scripts/man.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+shopt -s -o nounset
+
+count=0
+W=()
+_script="$(readlink -f ${BASH_SOURCE[0]})"
+_dir="$(dirname $_script)/../Documentation/services"
+filenames=$(ls $_dir | grep -I "pcn-*")
+
+#det current screen dimensions
+read -r WHIP_SIZE_Y WHIP_SIZE_X < <(stty size)
+
+for filename in $filenames
+do
+	W+=($count "$filename")	
+	let "count++"
+done
+
+CONTENT_SIZE=$((WHIP_SIZE_Y-9))
+OPTION=$(whiptail --title "Welcome to Polycube documentation" --menu "Choose a service. Full documentation at https://polycube-network.readthedocs.io/en/latest/index.html#" $WHIP_SIZE_Y $WHIP_SIZE_X $CONTENT_SIZE "${W[@]}" 3>&1 1>&2 2>&3)
+
+exitstatus=$?
+if [ $exitstatus = 0 ]; then
+	count=0
+	for dir in ${filenames[@]}
+	do
+		if [ $count = $OPTION ]; then
+			whiptail --textbox --scrolltext ${_dir}/${dir}/${dir:4}.rst $WHIP_SIZE_Y $WHIP_SIZE_X
+			break
+		else
+			let "count++"
+		fi
+	done
+fi


### PR DESCRIPTION
This bash based script allows to show services documentation in a whiptail dialog.

![launcher](https://user-images.githubusercontent.com/53214522/72457329-a33da580-37c6-11ea-8f62-7a6421038a6f.jpg)
![service](https://user-images.githubusercontent.com/53214522/72457334-a59fff80-37c6-11ea-8229-441d54e54561.jpg)
