### PR TITLE
Exporting TableDesc object to the BaseCube

### DIFF
--- a/src/libs/polycube/CMakeLists.txt
+++ b/src/libs/polycube/CMakeLists.txt
@@ -2,6 +2,18 @@ add_subdirectory(src)
 
 configure_file(libpolycube.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libpolycube.pc @ONLY)
 
+# In order to use the TableDesc class inside the BaseCube and let Polycube services
+# to be compiled outside of the base polycube services location,
+# we need these BCC header files to be present on the host filesystem.
+# By copying these source files from the BCC submodule to /usr/include/polycube,
+# we ensure to have them updated to the last BCC submodule version used in polycube.
+file(COPY
+            ../bcc/src/cc/table_desc.h
+            ../bcc/src/cc/file_desc.h
+            ../bcc/src/cc/bcc_exception.h
+        DESTINATION
+            ${CMAKE_CURRENT_SOURCE_DIR}/include/polycube/services)
+
 install(DIRECTORY include/ DESTINATION /usr/include)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libpolycube.pc

--- a/src/libs/polycube/include/polycube/services/base_cube.h
+++ b/src/libs/polycube/include/polycube/services/base_cube.h
@@ -29,6 +29,7 @@
 #include "polycube/services/cube_iface.h"
 #include "polycube/services/table.h"
 #include "polycube/services/utils.h"
+#include "polycube/services/table_desc.h"
 
 namespace polycube {
 namespace service {
@@ -71,6 +72,9 @@ class BaseCube {
       const std::string &table_name, int index = 0,
       ProgramType type = ProgramType::INGRESS);
 
+  const ebpf::TableDesc &get_table_desc(const std::string &table_name, int index,
+                                     ProgramType type);
+                                     
   virtual void datapath_log_msg(const LogMsg *msg);
 
   void set_log_level(LogLevel level);

--- a/src/libs/polycube/include/polycube/services/cube_iface.h
+++ b/src/libs/polycube/include/polycube/services/cube_iface.h
@@ -21,6 +21,7 @@
 #include "polycube/services/port_iface.h"
 #include "polycube/services/table.h"
 #include "polycube/services/types.h"
+#include "polycube/services/table_desc.h"
 
 #include <map>
 #include <string>
@@ -63,7 +64,9 @@ class BaseCubeIface {
   virtual uint16_t get_index(ProgramType type) const = 0;
   virtual int get_table_fd(const std::string &table_name, int index,
                            ProgramType type) = 0;
-
+  virtual const ebpf::TableDesc &get_table_desc(const std::string &table_name, int index,
+                                     ProgramType type) = 0;
+                                     
   virtual void set_log_level(LogLevel level) = 0;
   virtual LogLevel get_log_level() const = 0;
 

--- a/src/libs/polycube/src/base_cube.cpp
+++ b/src/libs/polycube/src/base_cube.cpp
@@ -43,6 +43,11 @@ int BaseCube::get_table_fd(const std::string &table_name, int index,
   return cube_->get_table_fd(table_name, index, type);
 }
 
+const ebpf::TableDesc &BaseCube::get_table_desc(const std::string &table_name, int index,
+                               ProgramType type) {
+  return cube_->get_table_desc(table_name, index, type);
+}
+
 void BaseCube::reload(const std::string &code, int index, ProgramType type) {
   cube_->reload(code, index, type);
 }

--- a/src/polycubed/src/base_cube.cpp
+++ b/src/polycubed/src/base_cube.cpp
@@ -140,6 +140,16 @@ int BaseCube::get_table_fd(const std::string &table_name, int index,
   }
 }
 
+const ebpf::TableDesc &BaseCube::get_table_desc(const std::string &table_name,
+                                         int index, ProgramType type) {
+  switch (type) {
+  case ProgramType::INGRESS:
+    return ingress_programs_[index]->get_table(table_name).getTableDescription();
+  case ProgramType::EGRESS:
+    return egress_programs_[index]->get_table(table_name).getTableDescription();
+  }
+}
+
 void BaseCube::reload(const std::string &code, int index, ProgramType type) {
   std::lock_guard<std::mutex> cube_guard(cube_mutex_);
   return do_reload(code, index, type);

--- a/src/polycubed/src/base_cube.h
+++ b/src/polycubed/src/base_cube.h
@@ -76,6 +76,8 @@ class BaseCube : virtual public BaseCubeIface {
   const Guid &uuid() const;
 
   int get_table_fd(const std::string &table_name, int index, ProgramType type);
+  const ebpf::TableDesc &get_table_desc(const std::string &table_name, int index,
+                             ProgramType type);
 
   void set_log_level(LogLevel level);
   LogLevel get_log_level() const;


### PR DESCRIPTION
Thanks to the changes done [here](https://github.com/polycube-network/bcc/pull/2), the BaseCube class can now get the description about the instantiated eBPF maps through the `TableDesc` class.

This PR adds all the methods needed to retrieve the TableDesc objects of the eBPF maps used in the ingress and egress programs of a Cube.