### PR TITLE
bypass the data format if the data is a string type

### DIFF
--- a/src/polycubectl/prettyprint.go
+++ b/src/polycubectl/prettyprint.go
@@ -296,6 +296,10 @@ func formatValue(data interface{}) string {
 	buf := ""
 	buf = fmt.Sprintf("%v", data)
 
+    if reflect.ValueOf(data).Kind() == reflect.String {
+        return buf
+    }
+
 	_, erri := strconv.ParseInt(buf, 10, 64)
 	if erri != nil {
 		f, errf := strconv.ParseFloat(buf, 64)


### PR DESCRIPTION
This prevents the number-like name being formatted as floating when using polycubectl to dump the cube information.

Refer to https://github.com/polycube-network/polycube/issues/16