### PR TITLE
Implementing maxPayload Pistache option personalization

### DIFF
--- a/src/polycubed/src/polycubed.cpp
+++ b/src/polycubed/src/polycubed.cpp
@@ -274,6 +274,7 @@ int main(int argc, char *argv[]) {
 
   // setup rest server
   int thr = 4;
+  size_t max_payload_size = 1024*1024; // 1MB
   Address addr(config.getServerIP(), Pistache::Port(config.getServerPort()));
 
   // logger->info("Cores = {0}", hardware_concurrency());
@@ -281,7 +282,7 @@ int main(int argc, char *argv[]) {
 
   // start rest server
   restserver = new RestServer(addr, *core);
-  restserver->init(thr, config.getCertPath(), config.getKeyPath(),
+  restserver->init(thr, max_payload_size, config.getCertPath(), config.getKeyPath(),
                    config.getCACertPath(), config.getCertWhitelistPath(),
                    config.getCertBlacklistPath());
   core->set_rest_server(restserver);

--- a/src/polycubed/src/rest_server.cpp
+++ b/src/polycubed/src/rest_server.cpp
@@ -116,15 +116,19 @@ int RestServer::client_verify_callback(int preverify_ok, void *ctx) {
   return preverify_ok;
 }
 
-void RestServer::init(size_t thr, const std::string &server_cert,
+void RestServer::init(size_t thr,
+                      size_t max_payload_size,
+                      const std::string &server_cert,
                       const std::string &server_key,
                       const std::string &root_ca_cert,
                       const std::string &whitelist_cert_path_,
                       const std::string &blacklist_cert_path_) {
   logger->debug("rest server will use {0} thread(s)", thr);
-  auto opts = Pistache::Http::Endpoint::options().threads(thr).flags(
-      Pistache::Tcp::Options::InstallSignalHandler |
-      Pistache::Tcp::Options::ReuseAddr);
+  auto opts = Pistache::Http::Endpoint::options()
+                  .threads(thr)
+                  .maxPayload(max_payload_size)
+                  .flags(Pistache::Tcp::Options::InstallSignalHandler |
+                         Pistache::Tcp::Options::ReuseAddr);
   httpEndpoint_->init(opts);
 
   if (!server_cert.empty()) {

--- a/src/polycubed/src/rest_server.h
+++ b/src/polycubed/src/rest_server.h
@@ -52,7 +52,9 @@ class RestServer {
 
   static const std::string base;
 
-  void init(size_t thr = 1, const std::string &server_cert = "",
+  void init(size_t thr = 1,
+            size_t max_payload_size = 64*1024,
+            const std::string &server_cert = "",
             const std::string &server_key = "",
             const std::string &root_ca_cert = "",
             const std::string &white_cert_list_path = "",


### PR DESCRIPTION
Currently the Pistache `maxPayload`  option has not been managed in the initialization of the Pistache server, so the HTTP requests with a payload size bigger than the default Pistache' setting produce a `Request exceeded maximum buffer size` response error message, with strange behaviors on the subsequent HTTP requests.

This PR adds the `maxPayload` option in the initialization of the Pistache server and set it to a default value of [`64KB`](https://github.com/polycube-network/polycube/blob/473f505c4f252e98473ea97a83bf9a17fd5166e1/src/polycubed/src/rest_server.h#L56).

The value of `maxPayload` is then customized in the rest server setup with a value of [`1MB`](https://github.com/polycube-network/polycube/blob/473f505c4f252e98473ea97a83bf9a17fd5166e1/src/polycubed/src/polycubed.cpp#L277).