### PR TITLE
This code fixes two bugs about "packetcapture" cube:

### DIFF
--- a/src/services/pcn-packetcapture/src/Packetcapture.cpp
+++ b/src/services/pcn-packetcapture/src/Packetcapture.cpp
@@ -216,7 +216,7 @@ void Packetcapture::packet_in(polycube::service::Direction direction,
     }
     break;
   }
-  send_packet_out(pkt, direction, false);
+  //send_packet_out(pkt, direction, false);
 }
 
 PacketcaptureCaptureEnum Packetcapture::getCapture() {

--- a/src/services/pcn-packetcapture/src/Packetcapture_dp_egress.c
+++ b/src/services/pcn-packetcapture/src/Packetcapture_dp_egress.c
@@ -192,6 +192,7 @@ static __always_inline int handle_rx(struct CTXTYPE *ctx, struct pkt_metadata *m
    */
 
   u16 reason = 1;
-  return pcn_pkt_controller(ctx, md, reason);
-
+  //return pcn_pkt_controller(ctx, md, reason);
+  u32 metadata[3] = { 0 } ;
+  return pcn_pkt_controller_with_metadata_stack( ctx, md, reason, metadata );
 }

--- a/src/services/pcn-packetcapture/src/Packetcapture_dp_ingress.c
+++ b/src/services/pcn-packetcapture/src/Packetcapture_dp_ingress.c
@@ -192,6 +192,8 @@ static __always_inline int handle_rx(struct CTXTYPE *ctx, struct pkt_metadata *m
    */
   
   u16 reason = 1;
-  return pcn_pkt_controller(ctx, md, reason);
+  // return pcn_pkt_controller(ctx, md, reason);
+   u32 metadata[3] = { 0 };
+   return pcn_pkt_controller_with_metadata_stack( ctx , md, reason, metadata );
 
 }


### PR DESCRIPTION
- activation of "packetcapture" on an interface makes it unreachable
- duplication of traffic in egress of an interface attached to
"packetcapture" service

On branch unreachable_interface_packetcapture_fixing
Changes to be committed:
	modified:   src/services/pcn-packetcapture/src/Packetcapture.cpp
	modified:   src/services/pcn-packetcapture/src/Packetcapture_dp_egress.c
	modified:   src/services/pcn-packetcapture/src/Packetcapture_dp_ingress.c