### PR TITLE
Changed packetcapture client name and fixed the buffer synchronization

### DIFF
--- a/src/services/pcn-packetcapture/client/packetcapture.py
+++ b/src/services/pcn-packetcapture/client/packetcapture.py
@@ -157,6 +157,7 @@ def listening():
     global f, stop
     while(1):
         if stop:
+            os.sync()
             f.close()
             break
         getAndWritePacket(sys.argv[1])


### PR DESCRIPTION
this pr makes the following changes:

- renamed folder "Packetcapture_Client" to "client"
- renamed "client.py" to "packetcapture.py"
- fixed buffer syncronization problem when producing the dump from the client (malformed packet)