### PR TITLE
Add traffic class to packet metadata

### DIFF
--- a/src/libs/polycube/include/polycube/services/cube.h
+++ b/src/libs/polycube/include/polycube/services/cube.h
@@ -77,6 +77,7 @@ Cube<PortType>::Cube(const nlohmann::json &conf,
 
     auto &p = *ports_by_id_.at(md->port_id);
     PacketInMetadata md_;
+    md_.traffic_class = md->traffic_class;
     md_.reason = md->reason;
     md_.metadata[0] = md->metadata[0];
     md_.metadata[1] = md->metadata[1];

--- a/src/libs/polycube/include/polycube/services/cube_factory.h
+++ b/src/libs/polycube/include/polycube/services/cube_factory.h
@@ -31,17 +31,20 @@ class TransparentCubeIface;
 enum class CubeType;
 
 struct PacketInMetadata {
+  uint32_t traffic_class;
   uint32_t reason;
   uint32_t metadata[3];
 };
 
 struct __attribute__((__packed__)) PacketIn {
-  uint16_t cube_id;    /**< Index of the Cube within the patchpanel */
-  uint16_t port_id;    /**< Port where the packet was received */
-  uint32_t packet_len; /**< Total length of the packet */
-  uint16_t reason;     /**< Internal code between dataplane and control plane */
-  uint32_t metadata[3]; /**< Buffer that can be used by the dataplane to send
-                           additional information to the control plane */
+  uint16_t cube_id;       /**< Index of the Cube within the patchpanel */
+  uint16_t port_id;       /**< Port where the packet was received */
+  uint32_t packet_len;    /**< Total length of the packet */
+  uint32_t traffic_class; /**< Traffic class the packet belongs to */
+  uint16_t reason;        /**< Internal code between dataplane and control
+                               plane */
+  uint32_t metadata[3];   /**< Buffer that can be used by the dataplane to send
+                               additional information to the control plane */
 };
 
 typedef std::function<void(const PacketIn *md,

--- a/src/libs/polycube/src/transparent_cube.cpp
+++ b/src/libs/polycube/src/transparent_cube.cpp
@@ -35,6 +35,7 @@ TransparentCube::TransparentCube(const nlohmann::json &conf,
 
     Direction direction = static_cast<Direction>(md->port_id);
     PacketInMetadata md_;
+    md_.traffic_class = md->traffic_class;
     md_.reason = md->reason;
     md_.metadata[0] = md->metadata[0];
     md_.metadata[1] = md->metadata[1];

--- a/src/polycubed/src/base_cube.cpp
+++ b/src/polycubed/src/base_cube.cpp
@@ -432,9 +432,10 @@ enum {
 };
 
 struct pkt_metadata {
-  u16 cube_id;      //__attribute__((deprecated)) // use CUBE_ID instead
-  u16 in_port;      // The interface on which a packet was received.
-  u32 packet_len;   //__attribute__((deprecated)) // Use ctx->len
+  u16 cube_id;        //__attribute__((deprecated)) // use CUBE_ID instead
+  u16 in_port;        // The interface on which a packet was received.
+  u32 packet_len;     //__attribute__((deprecated)) // Use ctx->len
+  u32 traffic_class;  // The traffic class the packet belongs to
 
   // used to send data to controller
   u16 reason;
@@ -468,9 +469,17 @@ void call_ingress_program(struct CTXTYPE *skb, int index) {
 }
 
 static __always_inline
+void call_ingress_program_with_metadata(struct CTXTYPE *skb,
+                                        struct pkt_metadata *md, int index);
+
+static __always_inline
 void call_egress_program(struct CTXTYPE *skb, int index) {
   egress_programs.call(skb, index);
 }
+
+static __always_inline
+void call_egress_program_with_metadata(struct CTXTYPE *skb,
+                                       struct pkt_metadata *md, int index);
 
 /* checksum related */
 

--- a/src/polycubed/src/controller.cpp
+++ b/src/polycubed/src/controller.cpp
@@ -40,6 +40,7 @@ struct metadata {
   u16 cube_id;
   u16 port_id;
   u32 packet_len;
+  u32 traffic_class;
   u16 reason;
   u32 md[3];  // generic metadata
 } __attribute__((packed));
@@ -69,6 +70,7 @@ int controller_module_tx(struct __sk_buff *ctx) {
   md.cube_id = module_index;
   md.port_id = in_port;
   md.packet_len = ctx->len;
+  md.traffic_class = ctx->mark;
   md.reason = reason;
 
   x = ctx->cb[2];
@@ -173,6 +175,7 @@ struct pkt_metadata {
   u16 cube_id;
   u16 in_port;
   u32 packet_len;
+  u32 traffic_class;
 
   // used to send data to controller
   u16 reason;
@@ -199,6 +202,7 @@ int controller_module_tx(struct xdp_md *ctx) {
   md.cube_id = int_md->cube_id;
   md.in_port = int_md->in_port;
   md.packet_len = (u32)(data_end - data);
+  md.traffic_class = int_md->traffic_class;
   md.reason = int_md->reason;
 
   x = int_md->md[0];
@@ -239,6 +243,7 @@ struct pkt_metadata {
   u16 module_index;
   u16 in_port;
   u32 packet_len;
+  u32 traffic_class;
 
   // used to send data to controller
   u16 reason;

--- a/src/polycubed/src/extiface_xdp.cpp
+++ b/src/polycubed/src/extiface_xdp.cpp
@@ -80,6 +80,7 @@ struct pkt_metadata {
   u16 module_index;
   u16 in_port;
   u32 packet_len;
+  u32 traffic_class;
   // used to send data to controller
   u16 reason;
   u32 md[3];

--- a/src/polycubed/src/transparent_cube_tc.cpp
+++ b/src/polycubed/src/transparent_cube_tc.cpp
@@ -93,7 +93,13 @@ const std::string TransparentCubeTC::TRANSPARENTCUBETC_WRAPPER = R"(
 int handle_rx_wrapper(struct CTXTYPE *skb) {
   struct pkt_metadata md = {};
   md.packet_len = skb->len;
+  md.traffic_class = skb->mark;
+  
   int rc = handle_rx(skb, &md);
+
+  // Save the traffic class for the next program in case it was changed
+  // by the current one
+  skb->mark = md.traffic_class;
 
   switch (rc) {
     case RX_DROP:

--- a/src/polycubed/src/transparent_cube_xdp.cpp
+++ b/src/polycubed/src/transparent_cube_xdp.cpp
@@ -127,8 +127,13 @@ int handle_rx_xdp_wrapper(struct CTXTYPE *ctx) {
   if (int_md) {
     md.cube_id = CUBE_ID;
     md.packet_len = int_md->packet_len;
+    md.traffic_class = int_md->traffic_class;
 
     int rc = handle_rx(ctx, &md);
+
+    // Save the traffic class for the next program in case it was changed
+    // by the current one
+    int_md->traffic_class = md.traffic_class;
 
     switch (rc) {
     case RX_DROP:


### PR DESCRIPTION
This PR adds support to store the traffic class of a packet in the packet metadata of the data plane.
The value is represented as a `uint32` field in `struct pkt_metadata`, and is propagated to all programs that compose the dataplane pipeline.
Traffic class is also made available among the metadata of the `packet_in()` method in the control plane of services.