### PR TITLE
Router bug fixes

### DIFF
--- a/src/libs/polycube/include/.gitignore
+++ b/src/libs/polycube/include/.gitignore
@@ -1,0 +1,3 @@
+bcc_exception.h
+file_desc.h
+table_desc.h

--- a/src/services/pcn-router/src/Ports.cpp
+++ b/src/services/pcn-router/src/Ports.cpp
@@ -203,6 +203,7 @@ void Ports::doSetIp(const std::string &new_ip) {
     r_port value = router_port.get(index);
     value.ip = ip_string_to_nbo_uint(ip_address);
     value.netmask = ip_string_to_nbo_uint(netmask);
+    router_port.set(index, value);
   } catch (...) {
     logger()->error("Port {0} not found in the data path", this->name());
   }

--- a/src/services/pcn-router/src/Ports.cpp
+++ b/src/services/pcn-router/src/Ports.cpp
@@ -142,6 +142,14 @@ Ports::Ports(polycube::service::Cube<Ports> &parent,
   };
 
   if (!parent_.get_shadow()) {
+    // Align parameters of the port with the ones of the interface if connected
+    if (conf.macIsSet()) {
+      set_peer_parameter("MAC", conf.getMac());
+    }
+    if (conf.ipIsSet()) {
+      set_peer_parameter("IP", conf.getIp());
+    }
+
     /* Register the new port to IP and MAC notifications arriving from ExtIface
      * do not use define because strings are easier to manipulate
      * for future extensions */

--- a/src/services/pcn-router/src/PortsSecondaryip.cpp
+++ b/src/services/pcn-router/src/PortsSecondaryip.cpp
@@ -36,7 +36,7 @@ PortsSecondaryip::PortsSecondaryip(Ports &parent, const PortsSecondaryipJsonObje
   /*
   * Add two routes in the routing table
   */
-  int index = parent.parent_.Cube::get_port(parent.getName())->index();
+  int index = parent.index();
   parent.parent_.add_local_route(ip_, parent.getName(), index);
 }
 


### PR DESCRIPTION
This PR fixes some bugs of the router service.
- There was an error when setting the secondary ip address during port initialization.
To replicate the problem try to create a router posting this json:
  ```
  {
    "ports": [
      {
        "name": "p1",
        "ip": "10.0.0.1/24",
        "secondaryip": [
          {"ip": "10.0.1.1/24"}
        ] 
      }
    ]
  }
  ```
  to `http://localhost:9000/polycube/v1/router/r1`, the creation of the cube will fail.
  Fixed with commit 079dbf10903aa01870d289a460ed872895d3c377.
- When adding a /32 address to an interface a local network was also added, this caused problems when trying to reach that ip.
To replicate:
  ```
  polycubectl router add r1
  polycubectl r1 ports add lo ip=172.99.0.1/32
  ```
  connect the router to a namespace and try to ping 172.99.0.1 (you need to add a route to this address in the namespace), the command will fail.
  Fixed with commit 9152c9f93190a74c23f9b1f7a9e0a5bf00f97073.
- When updating the ip address of an interface data in the dataplane was not updated.
Fixed with commit 46b28486733c0b91878e2ef98567d1fdd58bbb94.
- When creating a port connected to an interface of the host with parameters already set, parameters in the configuration of the cube were overwritten by the ones of the interface.
To replicate:
  ```
  sudo ip link add veth1 type veth peer name veth1_
  sudo ip addr add 10.0.0.1/24 dev veth1
  polycubectl router add r1
  polycubectl r1 ports add p1 ip=172.0.0.1/24 peer=veth1
  polycubectl r1 ports show
  ```
  Ip configuration of port p1 is overwritten by ip of veth1.
  Fixed with commit 8c5dfd6806d4bd7cbcb11c2bf0bf9dba7dbc6e38.

Additionally, I added some files to gitignore with commit f118df26fea9adc94b8a9fcb05c19a56acc645a6 (details in commit message).