### PR TITLE
Reduce Polycube overhead

### DIFF
--- a/src/libs/polycube/include/polycube/services/cube_iface.h
+++ b/src/libs/polycube/include/polycube/services/cube_iface.h
@@ -84,7 +84,8 @@ class CubeIface : virtual public BaseCubeIface {
   virtual void remove_port(const std::string &name) = 0;
   virtual std::shared_ptr<PortIface> get_port(const std::string &name) = 0;
 
-  virtual void update_forwarding_table(int index, int value) = 0;
+  virtual void update_forwarding_table(uint16_t port, uint32_t next,
+                                       bool is_netdev) = 0;
 
   virtual void set_conf(const nlohmann::json &conf) = 0;
   virtual nlohmann::json to_json() const = 0;
@@ -98,7 +99,7 @@ class CubeIface : virtual public BaseCubeIface {
 
 class TransparentCubeIface : virtual public BaseCubeIface {
  public:
-  virtual void set_next(uint32_t next, ProgramType type) = 0;
+  virtual void set_next(uint16_t next, ProgramType type, bool is_netdev) = 0;
   virtual void set_parameter(const std::string &parameter,
                              const std::string &value) = 0;
   virtual void send_packet_out(const std::vector<uint8_t> &packet, Direction direction,

--- a/src/polycubed/src/controller.h
+++ b/src/polycubed/src/controller.h
@@ -45,6 +45,7 @@ namespace polycubed {
 // struct used when sending a packet to an cube
 struct __attribute__((__packed__)) metadata {
   uint16_t module_index;
+  uint8_t is_netdev;
   uint16_t port_id;
 
 #define MD_PKT_FROM_CONTROLLER  (1UL << 0)
@@ -66,10 +67,11 @@ class Controller {
 
   void register_cb(int id, const packet_in_cb &cb);
   void unregister_cb(int id);
-  void send_packet_to_cube(uint16_t module_index, uint16_t port_id,
-                           const std::vector<uint8_t> &packet,
-                           service::Direction direction=service::Direction::INGRESS,
-                           bool mac_overwrite=false);
+  void send_packet_to_cube(
+      uint16_t module_index, bool is_netdev, uint16_t port_id,
+      const std::vector<uint8_t> &packet,
+      service::Direction direction=service::Direction::INGRESS,
+      bool mac_overwrite=false);
 
   int get_fd() const;
   uint32_t get_id() const;

--- a/src/polycubed/src/cube.h
+++ b/src/polycubed/src/cube.h
@@ -63,13 +63,11 @@ class Cube : public BaseCube, public CubeIface {
   std::shared_ptr<PortIface> get_port(const std::string &name);
   std::map<std::string, std::shared_ptr<PortIface>> &get_ports();
 
-  void update_forwarding_table(int index, int value);
+  void update_forwarding_table(uint16_t port, uint32_t next, bool is_netdev);
   
   // Sets the index of the next program to call after the egress program of this
   // cube is executed.
-  // The higher 16 bits are reserved for XDP programs, if they are set they
-  // override the value of the lower 16 bits.
-  void set_egress_next(int port, uint32_t index);
+  virtual void set_egress_next(int port, uint16_t index);
 
   void set_conf(const nlohmann::json &conf);
   nlohmann::json to_json() const;
@@ -84,11 +82,11 @@ class Cube : public BaseCube, public CubeIface {
   uint16_t allocate_port_id();
   void release_port_id(uint16_t id);
 
-  std::unique_ptr<ebpf::BPFArrayTable<uint32_t>> forward_chain_;
-  std::unique_ptr<ebpf::BPFArrayTable<uint32_t>> egress_next_;
+  std::unique_ptr<ebpf::BPFArrayTable<uint16_t>> egress_next_;
 
   std::map<std::string, std::shared_ptr<PortIface>> ports_by_name_;
   std::map<int, std::shared_ptr<PortIface>> ports_by_index_;
+  std::map<uint16_t, std::pair<uint32_t, bool>> forward_chain_;
   std::set<uint16_t> free_ports_;  // keeps track of available ports
 
   std::map<std::string, std::shared_ptr<Veth>> veth_by_name_;

--- a/src/polycubed/src/cube_tc.h
+++ b/src/polycubed/src/cube_tc.h
@@ -52,9 +52,11 @@ class CubeTC : public Cube {
 
  protected:
   static std::string get_wrapper_code();
+  std::string get_redirect_code();
 
-  static void do_compile(int module_index, ProgramType type, LogLevel level_,
-                         ebpf::BPF &bpf, const std::string &code, int index, bool shadow, bool span);
+  void do_compile(int module_index, ProgramType type, LogLevel level_,
+                  ebpf::BPF &bpf, const std::string &code, int index,
+                  bool shadow, bool span);
   static int do_load(ebpf::BPF &bpf);
   static void do_unload(ebpf::BPF &bpf);
 

--- a/src/polycubed/src/cube_xdp.h
+++ b/src/polycubed/src/cube_xdp.h
@@ -56,8 +56,12 @@ class CubeXDP : public Cube {
                   ProgramType type) override;
   void del_program(int index, ProgramType type) override;
 
+  void set_egress_next(int port, uint16_t index) override;
+  void set_egress_next_netdev(int port, uint16_t index);
+
  protected:
   static std::string get_wrapper_code();
+  std::string get_redirect_code();
 
   void compile(ebpf::BPF &bpf, const std::string &code, int index,
                ProgramType type);
@@ -75,6 +79,8 @@ class CubeXDP : public Cube {
   std::array<std::unique_ptr<ebpf::BPF>, _POLYCUBE_MAX_BPF_PROGRAMS>
       egress_programs_tc_;
   std::unique_ptr<ebpf::BPFProgTable> egress_programs_table_tc_;
+
+  std::unique_ptr<ebpf::BPFArrayTable<uint32_t>> egress_next_xdp_;
 
  private:
   static const std::string CUBEXDP_COMMON_WRAPPER;

--- a/src/polycubed/src/extiface.cpp
+++ b/src/polycubed/src/extiface.cpp
@@ -38,6 +38,7 @@ ExtIface::ExtIface(const std::string &iface)
     : PeerIface(iface_mutex_),
       iface_(iface),
       peer_(nullptr),
+      index_(0xffff),
       ingress_next_(0xffff),
       ingress_port_(0),
       egress_next_(0xffff),
@@ -70,30 +71,6 @@ ExtIface* ExtIface::get_extiface(const std::string &iface_name) {
 
 uint16_t ExtIface::get_index() const {
   return index_;
-}
-
-int ExtIface::load_tx() {
-  ebpf::StatusTuple res(0);
-  std::vector<std::string> flags;
-
-  int iface_index = Netlink::getInstance().get_iface_index(iface_);
-  flags.push_back(std::string("-DINTERFACE_INDEX=") +
-                  std::to_string(iface_index));
-
-  res = tx_.init(get_tx_code(), flags);
-  if (res.code() != 0) {
-    logger->error("Error compiling tx program: {}", res.msg());
-    throw BPFError("failed to init ebpf program:" + res.msg());
-  }
-
-  int fd_tx_;
-  auto load_res = tx_.load_func("handler", get_program_type(), fd_tx_);
-  if (load_res.code() != 0) {
-    logger->error("Error loading tx program: {}", load_res.msg());
-    throw BPFError("failed to load ebpf program: " + load_res.msg());
-  }
-
-  return fd_tx_;
 }
 
 int ExtIface::load_egress() {

--- a/src/polycubed/src/extiface.cpp
+++ b/src/polycubed/src/extiface.cpp
@@ -157,12 +157,16 @@ PeerIface *ExtIface::get_peer_iface() {
 void ExtIface::set_next_index(uint16_t index) {
   std::lock_guard<std::mutex> guard(iface_mutex_);
 
-  if (cubes_.size() != 0) {
-    auto last_cube = cubes_.back();
-    last_cube->set_next(index, ProgramType::INGRESS);
-  } else {
-    set_next(index, ProgramType::INGRESS);
+  // Find the last cube with an egress program
+  for (int i = cubes_.size() - 1; i >= 0; i++) {
+    if (cubes_[i]->get_index(ProgramType::INGRESS)) {
+      cubes_[i]->set_next(index, ProgramType::INGRESS);
+      return;
+    }
   }
+  
+  // If there is no cube, set next index of the rx program of the interface
+  set_next(index, ProgramType::INGRESS);
 }
 
 void ExtIface::set_next(uint16_t next, ProgramType type) {

--- a/src/polycubed/src/extiface.h
+++ b/src/polycubed/src/extiface.h
@@ -83,11 +83,9 @@ class ExtIface : public PeerIface {
   static std::map<std::string, ExtIface*> used_ifaces;
   virtual int load_ingress() = 0;
   int load_egress();
-  int load_tx();
 
   virtual std::string get_ingress_code() const = 0;
   virtual std::string get_egress_code() const = 0;
-  virtual std::string get_tx_code() const = 0;
   virtual bpf_prog_type get_program_type() const = 0;
 
   virtual void update_indexes() override;
@@ -96,7 +94,6 @@ class ExtIface : public PeerIface {
   std::unique_ptr<ebpf::BPF> egress_program_;
   void set_next(uint16_t next, ProgramType type);
 
-  ebpf::BPF tx_;
   std::string iface_;
   unsigned int ifindex_iface;
   PeerIface *peer_;  // the interface is connected to

--- a/src/polycubed/src/extiface.h
+++ b/src/polycubed/src/extiface.h
@@ -67,7 +67,6 @@ class ExtIface : public PeerIface {
   void set_parameter(const std::string &param_name,
                      const std::string &value) override;
   uint16_t get_next(ProgramType type);
-  TransparentCube* get_next_cube(ProgramType type);
   std::vector<std::string> get_service_chain(ProgramType type);
 
  protected:
@@ -82,7 +81,7 @@ class ExtIface : public PeerIface {
   std::mutex event_mutex;
 
   static std::map<std::string, ExtIface*> used_ifaces;
-  int load_ingress();
+  virtual int load_ingress() = 0;
   int load_egress();
   int load_tx();
 
@@ -93,8 +92,8 @@ class ExtIface : public PeerIface {
 
   virtual void update_indexes() override;
 
-  ebpf::BPF ingress_program_;
-  ebpf::BPF egress_program_;
+  std::unique_ptr<ebpf::BPF> ingress_program_;
+  std::unique_ptr<ebpf::BPF> egress_program_;
   void set_next(uint16_t next, ProgramType type);
 
   ebpf::BPF tx_;
@@ -103,9 +102,11 @@ class ExtIface : public PeerIface {
   PeerIface *peer_;  // the interface is connected to
 
   uint16_t index_;
-  uint16_t next_index_;
-
-  bool egress_program_loaded;
+  // 0xffff means there is no next program, let the packet pass
+  uint16_t ingress_next_;
+  uint16_t ingress_port_;
+  uint16_t egress_next_;
+  uint16_t egress_port_;
 
   mutable std::mutex iface_mutex_;
 

--- a/src/polycubed/src/extiface_tc.cpp
+++ b/src/polycubed/src/extiface_tc.cpp
@@ -29,12 +29,9 @@ namespace polycubed {
 ExtIfaceTC::ExtIfaceTC(const std::string &iface) : ExtIface(iface) {
   try {
     std::unique_lock<std::mutex> bcc_guard(bcc_mutex);
-    int fd_rx = load_ingress();
     int fd_tx = load_tx();
-    load_egress();
-
     index_ = PatchPanel::get_tc_instance().add(fd_tx);
-    Netlink::getInstance().attach_to_tc(iface_, fd_rx);
+
   } catch (...) {
     used_ifaces.erase(iface);
     throw;
@@ -43,7 +40,53 @@ ExtIfaceTC::ExtIfaceTC(const std::string &iface) : ExtIface(iface) {
 
 ExtIfaceTC::~ExtIfaceTC() {
   PatchPanel::get_tc_instance().remove(index_);
-  Netlink::getInstance().detach_from_tc(iface_);
+  if (ingress_program_) {
+    Netlink::getInstance().detach_from_tc(iface_);
+  }
+}
+
+int ExtIfaceTC::load_ingress() {
+  if (ingress_next_ == 0xffff) {
+    // No next program, remove the rx program
+    if (ingress_program_) {
+      Netlink::getInstance().detach_from_tc(iface_, ATTACH_MODE::INGRESS);
+      ingress_program_.reset();
+    }
+
+    return -1;
+  }
+
+  ebpf::StatusTuple res(0);
+
+  std::vector<std::string> flags;
+
+  flags.push_back(std::string("-DMOD_NAME=") + iface_);
+  flags.push_back(std::string("-D_POLYCUBE_MAX_NODES=") +
+                  std::to_string(PatchPanel::_POLYCUBE_MAX_NODES));
+  flags.push_back(std::string("-DNEXT_PROGRAM=") +
+                  std::to_string(ingress_next_));
+  flags.push_back(std::string("-DNEXT_PORT=") + std::to_string(ingress_port_));
+
+  std::unique_ptr<ebpf::BPF> program = std::make_unique<ebpf::BPF>();
+
+  res = program->init(get_ingress_code(), flags);
+  if (res.code() != 0) {
+    logger->error("Error compiling ingress program: {}", res.msg());
+    throw BPFError("failed to init ebpf program:" + res.msg());
+  }
+
+  int fd;
+  res = program->load_func("handler", BPF_PROG_TYPE_SCHED_CLS, fd);
+  if (res.code() != 0) {
+    logger->error("Error loading ingress program: {}", res.msg());
+    throw BPFError("failed to load ebpf program: " + res.msg());
+  }
+
+  Netlink::getInstance().attach_to_tc(iface_, fd, ATTACH_MODE::INGRESS);
+
+  ingress_program_ = std::move(program);
+
+  return fd;
 }
 
 std::string ExtIfaceTC::get_ingress_code() const {
@@ -66,22 +109,12 @@ const std::string ExtIfaceTC::RX_CODE = R"(
 #include <uapi/linux/pkt_cls.h>
 
 BPF_TABLE("extern", int, int, nodes, _POLYCUBE_MAX_NODES);
-// TODO: how does it impact the performance?
-BPF_TABLE("array", int, u32, index_map, 1);
 
 int handler(struct __sk_buff *skb) {
-  //bpf_trace_printk("ingress %d %x\n", skb->ifindex, INDEX);
+  skb->cb[0] = NEXT_PORT << 16;
+  nodes.call(skb, NEXT_PROGRAM);
 
-  int zero = 0;
-  u32 *index = index_map.lookup(&zero);
-  if (!index)
-    return TC_ACT_OK;
-
-  skb->cb[0] = *index;
-  nodes.call(skb, *index & 0xFFFF);
-
-  //bpf_trace_printk("miss tailcall\n");
-  return TC_ACT_OK;
+  return TC_ACT_SHOT;
 }
 )";
 

--- a/src/polycubed/src/extiface_tc.h
+++ b/src/polycubed/src/extiface_tc.h
@@ -42,6 +42,8 @@ class ExtIfaceTC : public ExtIface {
   virtual ~ExtIfaceTC();
 
  protected:
+  int load_ingress();
+
   virtual std::string get_ingress_code() const;
   virtual std::string get_egress_code() const;
   virtual std::string get_tx_code() const;

--- a/src/polycubed/src/extiface_tc.h
+++ b/src/polycubed/src/extiface_tc.h
@@ -46,11 +46,9 @@ class ExtIfaceTC : public ExtIface {
 
   virtual std::string get_ingress_code() const;
   virtual std::string get_egress_code() const;
-  virtual std::string get_tx_code() const;
   virtual bpf_prog_type get_program_type() const;
 
   static const std::string RX_CODE;
-  static const std::string TX_CODE;
 };
 
 }  // namespace polycubed

--- a/src/polycubed/src/extiface_xdp.h
+++ b/src/polycubed/src/extiface_xdp.h
@@ -57,13 +57,9 @@ class ExtIfaceXDP : public ExtIface {
  private:
   virtual std::string get_ingress_code() const;
   virtual std::string get_egress_code() const;
-  virtual std::string get_tx_code() const;
   virtual bpf_prog_type get_program_type() const;
 
-  uint16_t redir_index_;
-
   static const std::string XDP_PROG_CODE;
-  static const std::string XDP_REDIR_PROG_CODE;
 
   int attach_flags_;
 };

--- a/src/polycubed/src/extiface_xdp.h
+++ b/src/polycubed/src/extiface_xdp.h
@@ -47,6 +47,8 @@ class ExtIfaceXDP : public ExtIface {
   virtual ~ExtIfaceXDP();
 
  protected:
+  int load_ingress();
+
   // XDP egress programs can't rely on the TC_EGRESS hook to be executed.
   // This version of update_indexes() also connects the egress programs chain to
   // the peer of the interface (if present).

--- a/src/polycubed/src/port.cpp
+++ b/src/polycubed/src/port.cpp
@@ -73,15 +73,22 @@ void Port::set_next_index(uint16_t index) {
     return;
   }
 
+  bool is_netdev = false;
+  if (index == 0xffff) {
+    // Peer is a netdev, get its index
+    index = peer_port_->get_port_id();
+    is_netdev = true;
+  }
+
   // it there is loaded an egrees cube, set next on it
   for (auto it = cubes_.rbegin(); it != cubes_.rend(); ++it) {
     if ((*it)->get_index(ProgramType::EGRESS)) {
-      (*it)->set_next(index, ProgramType::EGRESS);
+      (*it)->set_next(index, ProgramType::EGRESS, is_netdev);
       return;
     }
   }
 
-  update_parent_fwd_table(index);
+  update_parent_fwd_table(index, is_netdev);
 }
 
 void Port::set_peer_iface(PeerIface *peer) {
@@ -95,7 +102,7 @@ PeerIface *Port::get_peer_iface() {
   return peer_port_;
 }
 
-void Port::set_parent_egress_next(uint32_t index) {
+void Port::set_parent_egress_next(uint16_t index) {
   Cube &parent = dynamic_cast<Cube &>(parent_);
   parent.set_egress_next(get_port_id(), index);
 }
@@ -113,7 +120,7 @@ uint16_t Port::get_egress_index() const {
   return parent_.get_index(ProgramType::EGRESS);
 }
 
-void Port::update_parent_fwd_table(uint16_t next) {
+void Port::update_parent_fwd_table(uint16_t next, bool is_netdev) {
   uint16_t id;
 
   if (dynamic_cast<Port *>(peer_port_)) {
@@ -127,7 +134,7 @@ void Port::update_parent_fwd_table(uint16_t next) {
     id = get_port_id();
   }
 
-  parent_.update_forwarding_table(index(), next | id << 16);
+  parent_.update_forwarding_table(index(), next | id << 16, is_netdev);
 }
 
 std::string Port::name() const {
@@ -230,6 +237,7 @@ void Port::send_packet_out(const std::vector<uint8_t> &packet,
 
   uint16_t port;
   uint16_t module;
+  bool is_netdev = false;
 
   if (recirculate) {
     module = get_parent_index();
@@ -237,6 +245,12 @@ void Port::send_packet_out(const std::vector<uint8_t> &packet,
   } else if (peer_port_) {
     module = peer_port_->get_index();
     if (dynamic_cast<ExtIface *>(peer_port_)) {
+      if (module == 0xffff) {
+        // No cubes to execute, redirect the packet to the netdev
+        module = peer_port_->get_port_id();
+        is_netdev = true;
+      }
+
       // If peer is an interface use this port anyway, so it can be used by the
       // possible egress program of the parent
       port = get_port_id();
@@ -246,7 +260,7 @@ void Port::send_packet_out(const std::vector<uint8_t> &packet,
       port = peer_port_->get_port_id();
     }
   }
-  c.send_packet_to_cube(module, port, packet);
+  c.send_packet_to_cube(module, is_netdev, port, packet);
 }
 
 void Port::send_packet_ns(const std::vector<uint8_t> &packet) {
@@ -256,73 +270,44 @@ void Port::send_packet_ns(const std::vector<uint8_t> &packet) {
 }
 
 void Port::update_indexes() {
-  int i;
+  uint16_t next;
 
-  // TODO: could we avoid to recalculate in case there is not peer?
-
-  std::vector<uint16_t> ingress_indexes(cubes_.size());
-  std::vector<uint16_t> egress_indexes(cubes_.size());
-
-  for (i = 0; i < cubes_.size(); i++) {
-    ingress_indexes[i] = cubes_[i]->get_index(ProgramType::INGRESS);
-    egress_indexes[i] = cubes_[i]->get_index(ProgramType::EGRESS);
-  }
-
-  // ingress chain: peer -> cube[N-1] -> ... -> cube[0] -> port
-  // CASE2: cube[0] -> port
-  for (i = 0; i < cubes_.size(); i++) {
-    if (ingress_indexes[i]) {
-      cubes_[i]->set_next(get_parent_index(), ProgramType::INGRESS);
-      break;
+  // Link cubes of ingress chain
+  // port <- cubes[0] <- ... <- cubes[N-1] <- peer
+  
+  next = get_parent_index();
+  for (int i = 0; i < cubes_.size(); i++) {
+    if (cubes_[i]->get_index(ProgramType::INGRESS)) {
+      cubes_[i]->set_next(next, ProgramType::INGRESS);
+      next = cubes_[i]->get_index(ProgramType::INGRESS);
     }
   }
 
-  // cube[N-1] -> ... -> cube[0]
-  for (int j = i + 1; j < cubes_.size(); j++) {
-    if (ingress_indexes[j]) {
-      cubes_[j]->set_next(ingress_indexes[i], ProgramType::INGRESS);
-      i = j;
-    }
-  }
+  port_index_ = next;
 
-  port_index_ = calculate_index();
-
-  // CASE4: peer -> cube[N-1]
   if (peer_port_) {
-    peer_port_->set_next_index(port_index_);
+    peer_port_->set_next_index(next);
   }
 
-  // egress chain: port -> cubes[0] -> ... -> cube[N -1] -> peer
-  // CASE3: cube[N-1] -> peer
-  uint16_t egress_next = peer_port_ ? peer_port_->get_index() : 0;
-  for (i = cubes_.size() - 1; i >= 0; i--) {
-    if (egress_indexes[i]) {
-      cubes_[i]->set_next(egress_next, ProgramType::EGRESS);
-      break;
+  // Link cubes of egress chain
+  // peer <- cubes[N-1] <- ... <- cubes[0] <- port
+
+  next = peer_port_ ? peer_port_->get_index() : 0;
+  bool is_netdev = false;
+  if (next == 0xffff) {
+    // Next is a netdev, get its index
+    next = peer_port_->get_port_id();
+    is_netdev = true;
+  }
+  for (int i = cubes_.size()-1; i >= 0; i--) {
+    if (cubes_[i]->get_index(ProgramType::EGRESS)) {
+      cubes_[i]->set_next(next, ProgramType::EGRESS, is_netdev);
+      next = cubes_[i]->get_index(ProgramType::EGRESS);
+      is_netdev = false;
     }
   }
 
-  if (i < 0) {
-    update_parent_fwd_table(egress_next);
-    return;
-  }
-
-  // cube[N-2] -> Tcube[N-1] (egress)
-  // i = 0;
-  for (int j = i - 1; j >= 0; j--) {
-    if (egress_indexes[j]) {
-      cubes_[j]->set_next(egress_indexes[i], ProgramType::EGRESS);
-      i = j;
-    }
-  }
-
-  // CASE1: port -> cubes[0]
-  for (i = 0; i < cubes_.size(); i++) {
-    if (egress_indexes[i]) {
-      update_parent_fwd_table(egress_indexes[i]);
-      break;
-    }
-  }
+  update_parent_fwd_table(next, is_netdev);
 }
 
 void Port::connect(PeerIface &p1, PeerIface &p2) {

--- a/src/polycubed/src/port.h
+++ b/src/polycubed/src/port.h
@@ -61,7 +61,7 @@ class Port : public polycube::service::PortIface, public PeerIface {
 
   // Sets the index of the next program on this port in the egress program of
   // the parent cube.
-  void set_parent_egress_next(uint32_t index); 
+  virtual void set_parent_egress_next(uint16_t index);
 
   // TODO: rename this
   uint16_t index() const;
@@ -103,7 +103,7 @@ class Port : public polycube::service::PortIface, public PeerIface {
 
  protected:
   void update_indexes() override;
-  void update_parent_fwd_table(uint16_t next);
+  void update_parent_fwd_table(uint16_t next, bool is_netdev);
   uint16_t get_parent_index() const;
 
   PortType type_;

--- a/src/polycubed/src/port_xdp.cpp
+++ b/src/polycubed/src/port_xdp.cpp
@@ -49,5 +49,16 @@ unsigned int PortXDP::get_peer_ifindex() const {
   return Netlink::getInstance().get_iface_index(peer_);
 }
 
+void PortXDP::set_parent_egress_next(uint16_t index) {
+  if (index == 0xffff) {
+    // Next is a netdev: the TC version of the program needs to pass the packet
+    // while the XDP one needs to redirect it
+    CubeXDP &parent = dynamic_cast<CubeXDP &>(parent_);
+    parent.set_egress_next_netdev(get_port_id(), peer_port_->get_port_id());
+  } else {
+    Port::set_parent_egress_next(index);
+  };
+}
+
 }  // namespace polycube
 }  // namespace polycubed

--- a/src/polycubed/src/port_xdp.h
+++ b/src/polycubed/src/port_xdp.h
@@ -36,6 +36,8 @@ class PortXDP : public Port {
   int get_attach_flags() const;
   unsigned int get_peer_ifindex() const;
 
+  void set_parent_egress_next(uint16_t index) override;
+
  private:
   void attach_xdp(const std::string &peer);
   void detach_xdp();

--- a/src/polycubed/src/transparent_cube.h
+++ b/src/polycubed/src/transparent_cube.h
@@ -34,11 +34,10 @@ class TransparentCube : public BaseCube, public TransparentCubeIface {
                            CubeType type, const service::attach_cb &attach);
   virtual ~TransparentCube();
 
-  // Sets the index of the next program to call after the program of the given
-  // direction is executed.
-  // The higher 16 bits are reserved for XDP programs, if they are set they
-  // override the value of the lower 16 bits.
-  void set_next(uint32_t next, ProgramType type);
+  // Sets the index of the next program or iterface to call after the program of
+  // the given direction is executed.
+  virtual void set_next(uint16_t next, ProgramType type,
+                        bool is_netdev = false);
   uint16_t get_next(ProgramType type);
   void set_parent(PeerIface *parent);
   PeerIface *get_parent();
@@ -59,8 +58,9 @@ class TransparentCube : public BaseCube, public TransparentCubeIface {
   service::attach_cb attach_;
   PeerIface *parent_;
   static std::string get_wrapper_code();
-  uint32_t ingress_next_;
-  uint32_t egress_next_;
+  uint16_t ingress_next_;
+  uint16_t egress_next_;
+  bool egress_next_is_netdev_;
 
   std::unordered_map<std::string, ParameterEventCallback> subscription_list;
   std::mutex subscription_list_mutex;

--- a/src/polycubed/src/transparent_cube_tc.h
+++ b/src/polycubed/src/transparent_cube_tc.h
@@ -45,8 +45,8 @@ class TransparentCubeTC : virtual public TransparentCube {
   virtual ~TransparentCubeTC();
 
  protected:
-  static void do_compile(int module_index, uint16_t next, ProgramType type,
-                         LogLevel level_, ebpf::BPF &bpf,
+  static void do_compile(int module_index, uint16_t next, bool is_netdev,
+                         ProgramType type, LogLevel level_, ebpf::BPF &bpf,
                          const std::string &code, int index);
   static std::string get_wrapper_code();
 

--- a/src/polycubed/src/transparent_cube_xdp.cpp
+++ b/src/polycubed/src/transparent_cube_xdp.cpp
@@ -33,7 +33,9 @@ TransparentCubeXDP::TransparentCubeXDP(
     const std::vector<std::string> &egress_code, LogLevel level, CubeType type,
     const service::attach_cb &attach)
     : TransparentCube(name, service_name, PatchPanel::get_xdp_instance(), level,
-                      type, attach) {
+                      type, attach),
+      egress_next_tc_(0),
+      egress_next_tc_is_netdev_(false) {
   egress_programs_table_tc_ = std::move(egress_programs_table_);
   auto table = master_program_->get_prog_table("egress_programs_xdp");
   egress_programs_table_ =
@@ -45,6 +47,28 @@ TransparentCubeXDP::TransparentCubeXDP(
 TransparentCubeXDP::~TransparentCubeXDP() {
   // it cannot be done in Cube::~Cube() because calls a virtual method
   TransparentCube::uninit();
+}
+
+void TransparentCubeXDP::set_next(uint16_t next, ProgramType type,
+                                  bool is_netdev) {
+  if (type == ProgramType::EGRESS) {
+    egress_next_tc_ = next;
+    egress_next_tc_is_netdev_ = is_netdev;
+  }
+
+  TransparentCube::set_next(next, type, is_netdev);
+}
+
+void TransparentCubeXDP::set_egress_next(uint16_t next_xdp,
+                                         bool next_xdp_is_netdev,
+                                         uint16_t next_tc,
+                                         bool next_tc_is_netdev) {
+  egress_next_ = next_xdp;
+  egress_next_is_netdev_ = next_xdp_is_netdev;
+  egress_next_tc_ = next_tc;
+  egress_next_tc_is_netdev_ = next_tc_is_netdev;
+  
+  reload_all();
 }
 
 std::string TransparentCubeXDP::get_wrapper_code() {
@@ -75,7 +99,8 @@ void TransparentCubeXDP::reload(const std::string &code, int index,
                           egress_programs_tc_.at(index).get()));
 
         bcc_guard.unlock();
-        TransparentCubeTC::do_compile(get_id(), egress_next_,
+        TransparentCubeTC::do_compile(get_id(), egress_next_tc_,
+                                      egress_next_tc_is_netdev_,
                                       ProgramType::EGRESS, level_,
                                       *new_bpf_program, code, 0);
         int fd = CubeTC::do_load(*new_bpf_program);
@@ -121,7 +146,8 @@ void TransparentCubeXDP::reload_all() {
                           egress_programs_tc_.at(i).get()));
 
         bcc_guard.unlock();
-        TransparentCubeTC::do_compile(get_id(), egress_next_,
+        TransparentCubeTC::do_compile(get_id(), egress_next_tc_,
+                                      egress_next_tc_is_netdev_,
                                       ProgramType::EGRESS, level_,
                                       *new_bpf_program, egress_code_[i], 0);
         int fd = CubeTC::do_load(*new_bpf_program);
@@ -164,7 +190,8 @@ int TransparentCubeXDP::add_program(const std::string &code, int index, ProgramT
                                 egress_programs_.at(index).get()));
 
         bcc_guard.unlock();
-        TransparentCubeTC::do_compile(get_id(), egress_next_,
+        TransparentCubeTC::do_compile(get_id(), egress_next_tc_,
+                                      egress_next_tc_is_netdev_,
                                       ProgramType::EGRESS, level_,
                                       *egress_programs_tc_.at(index), code, 0);
         int fd = CubeTC::do_load(*egress_programs_tc_.at(index));
@@ -216,12 +243,15 @@ void TransparentCubeXDP::del_program(int index, ProgramType type) {
 void TransparentCubeXDP::compile(ebpf::BPF &bpf, const std::string &code,
                                  int index, ProgramType type) {
   uint16_t next;
+  bool is_netdev;
   switch (type) {
   case ProgramType::INGRESS:
     next = ingress_next_;
+    is_netdev = false;
     break;
   case ProgramType::EGRESS:
-    next = egress_next_ >> 16 == 0 ? egress_next_ : egress_next_ >> 16;
+    next = egress_next_;
+    is_netdev = egress_next_is_netdev_;
     break;
   }
 
@@ -236,8 +266,10 @@ void TransparentCubeXDP::compile(ebpf::BPF &bpf, const std::string &code,
   cflags.push_back(std::string("-DPOLYCUBE_XDP=1"));
   cflags.push_back(std::string("-DCTXTYPE=") + std::string("xdp_md"));
   cflags.push_back(std::string("-DNEXT=" + std::to_string(next)));
-  cflags.push_back(std::string("-DPOLYCUBE_PROGRAM_TYPE=" +
-                   std::to_string(static_cast<int>(type))));
+  cflags.push_back(std::string("-DNEXT_IS_NETDEV=") +
+                   std::to_string(int(is_netdev)));
+  cflags.push_back(std::string("-DPOLYCUBE_PROGRAM_TYPE=") +
+                   std::to_string(static_cast<int>(type)));
 
   std::lock_guard<std::mutex> guard(bcc_mutex);
   auto init_res = bpf.init(all_code, cflags);
@@ -275,11 +307,13 @@ int handle_rx_xdp_wrapper(struct CTXTYPE *ctx) {
       return XDP_DROP;
 
     case RX_OK:
-#if NEXT == 0xffff
-    return XDP_PASS;
+#if NEXT_IS_NETDEV
+      return bpf_redirect(NEXT, 0);
+#elif NEXT == 0xffff
+      return XDP_PASS;
 #else
-    xdp_nodes.call(ctx, NEXT);
-    return XDP_ABORTED;
+      xdp_nodes.call(ctx, NEXT);
+      return XDP_ABORTED;
 #endif
   }
 

--- a/src/polycubed/src/transparent_cube_xdp.h
+++ b/src/polycubed/src/transparent_cube_xdp.h
@@ -41,6 +41,14 @@ class TransparentCubeXDP : virtual public TransparentCube {
                               const service::attach_cb &attach);
   virtual ~TransparentCubeXDP();
 
+  void set_next(uint16_t next, ProgramType type,
+                bool is_netdev = false) override;
+
+  // Allows to set a different next program or interface for the XDP and TC
+  // versions of the egress program
+  void set_egress_next(uint16_t next_xdp, bool next_xdp_is_netdev,
+                       uint16_t next_tc, bool next_tc_is_netdev);
+
   void reload(const std::string &code, int index, ProgramType type) override;
   int add_program(const std::string &code, int index,
                   ProgramType type) override;
@@ -62,6 +70,9 @@ class TransparentCubeXDP : virtual public TransparentCube {
 
  private:
   static const std::string TRANSPARENTCUBEXDP_WRAPPER;
+
+  uint16_t egress_next_tc_;
+  bool egress_next_tc_is_netdev_;
 };
 
 }  // namespace polycubed

--- a/src/polycubed/src/utils/netlink.cpp
+++ b/src/polycubed/src/utils/netlink.cpp
@@ -307,19 +307,19 @@ void Netlink::attach_to_tc(const std::string &iface, int fd, ATTACH_MODE mode) {
   t.tcm_family = AF_UNSPEC;
   t.tcm_ifindex = rtnl_link_get_ifindex(link);
 
-  t.tcm_handle = TC_HANDLE(0, 0);
+  t.tcm_handle = TC_HANDLE(0, 1);
 
   switch (mode) {
   case ATTACH_MODE::EGRESS:
-    t.tcm_parent = TC_H_MAKE(TC_H_INGRESS, 0xFFF3U);  // why that number?
+    t.tcm_parent = TC_H_MAKE(TC_H_CLSACT, TC_H_MIN_EGRESS);
     break;
   case ATTACH_MODE::INGRESS:
-    t.tcm_parent = TC_H_MAKE(TC_H_INGRESS, 0xFFF2U);  // why that number?
+    t.tcm_parent = TC_H_MAKE(TC_H_CLSACT, TC_H_MIN_INGRESS);
     break;
   }
 
   protocol = htons(ETH_P_ALL);
-  prio = 0;
+  prio = 1;
   t.tcm_info = TC_H_MAKE(prio << 16, protocol);
 
   struct nl_msg *msg;
@@ -333,7 +333,7 @@ void Netlink::attach_to_tc(const std::string &iface, int fd, ATTACH_MODE mode) {
   }
 
   hdr = nlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, RTM_NEWTFILTER, sizeof(t),
-                  NLM_F_REQUEST | NLM_F_EXCL | NLM_F_CREATE);
+                  NLM_F_REQUEST | NLM_F_CREATE);
   memcpy(nlmsg_data(hdr), &t, sizeof(t));
 
   NLA_PUT_STRING(msg, TCA_KIND, "bpf");

--- a/src/polycubed/src/utils/utils.cpp
+++ b/src/polycubed/src/utils/utils.cpp
@@ -67,6 +67,19 @@ std::map<std::string, std::string> strip_port_peers(json &cubes) {
   return peers;
 }
 
+// Used to replace strings in datapath code
+void replaceStrAll(std::string &str, const std::string &from, const std::string &to) {
+  if (from.empty())
+    return;
+
+  size_t start_pos = 0;
+  while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
+    str.replace(start_pos, from.length(), to);
+    start_pos += to.length();  // In case 'to' contains 'from', like replacing
+    // 'x' with 'yx'
+  }
+}
+
 std::map<std::string, json> strip_port_tcubes(json &jcube) {
   std::map<std::string, json> cubes;
 

--- a/src/polycubed/src/utils/utils.h
+++ b/src/polycubed/src/utils/utils.h
@@ -28,6 +28,7 @@ bool check_kernel_version(const std::string &version);
 std::map<std::string, std::string> strip_port_peers(json &cubes);
 std::map<std::string, json> strip_port_tcubes(json &jcube);
 std::string decode_url(const std::string &url);
+void replaceStrAll(std::string &str, const std::string &from, const std::string &to);
 
 }  // namespace utils
 }  // namespace polycubed

--- a/src/services/pcn-bridge/src/Bridge.cpp
+++ b/src/services/pcn-bridge/src/Bridge.cpp
@@ -117,8 +117,6 @@ void Bridge::broadcastPacket(Ports &port,
   uint16_t vlan = md.metadata[0];
   logger()->trace("metadata vlan:{0} tagged:{1}", vlan, tagged);
 
-  std::lock_guard<std::mutex> guard(ports_mutex_);
-
   for (auto &it : get_ports()) {
     if (it->name() == port.name()) {
       continue;
@@ -137,8 +135,6 @@ std::vector<std::shared_ptr<Ports>> Bridge::getPortsList() {
 }
 
 void Bridge::addPorts(const std::string &name, const PortsJsonObject &conf) {
-  std::lock_guard<std::mutex> guard(ports_mutex_);
-
   BridgeBase::addPorts(name, conf);
 }
 
@@ -152,8 +148,6 @@ void Bridge::replacePorts(const std::string &name,
 }
 
 void Bridge::delPorts(const std::string &name) {
-  std::lock_guard<std::mutex> guard(ports_mutex_);
-
   BridgeBase::delPorts(name);
 }
 

--- a/src/services/pcn-bridge/src/Bridge.h
+++ b/src/services/pcn-bridge/src/Bridge.h
@@ -119,7 +119,6 @@ class Bridge : public BridgeBase {
   bool stp_enabled_;
   std::shared_ptr<Fdb> fdb_;
   std::unordered_map<uint16_t, std::shared_ptr<Stp>> stps_;
-  std::mutex ports_mutex_;
   std::thread timestamp_update_thread_;
   std::atomic<bool> quit_thread_;
 };

--- a/src/services/pcn-router/src/Router_dp.c
+++ b/src/services/pcn-router/src/Router_dp.c
@@ -275,7 +275,8 @@ static int handle_rx(struct CTXTYPE *ctx, struct pkt_metadata *md) {
   pcn_log(ctx, LOG_TRACE, "in_port: %d, proto: 0x%x, mac_src: %M mac_dst: %M",
           md->in_port, bpf_htons(eth->proto), eth->src, eth->dst);
 
-  struct r_port *in_port = router_port.lookup(&md->in_port);
+  u16 in_port_index = md->in_port;
+  struct r_port *in_port = router_port.lookup(&in_port_index);
   if (!in_port) {
     pcn_log(ctx, LOG_ERR, "received packet from non valid port: %d",
             md->in_port);

--- a/src/services/pcn-simplebridge/src/Simplebridge.cpp
+++ b/src/services/pcn-simplebridge/src/Simplebridge.cpp
@@ -99,9 +99,6 @@ void Simplebridge::flood_packet(Port &port, PacketInMetadata &md,
                                 const std::vector<uint8_t> &packet) {
   EthernetII p(&packet[0], packet.size());
 
-  // avoid adding or removing ports while flooding packet
-  std::lock_guard<std::mutex> guard(ports_mutex_);
-
   for (auto &it : get_ports()) {
     if (it->name() == port.name()) {
       continue;

--- a/src/services/pcn-simplebridge/src/Simplebridge.h
+++ b/src/services/pcn-simplebridge/src/Simplebridge.h
@@ -69,5 +69,4 @@ class Simplebridge : public SimplebridgeBase {
 
   void flood_packet(Port &port, PacketInMetadata &md,
                     const std::vector<uint8_t> &packet);
-  std::mutex ports_mutex_;
 };

--- a/src/services/pcn-simpleforwarder/src/Simpleforwarder_dp.c
+++ b/src/services/pcn-simpleforwarder/src/Simpleforwarder_dp.c
@@ -37,7 +37,8 @@ static __always_inline int handle_rx(struct CTXTYPE *ctx,
   pcn_log(ctx, LOG_TRACE, "XDP Cube", md->in_port);
 #endif
   pcn_log(ctx, LOG_TRACE, "Receiving packet from port %d", md->in_port);
-  struct action *x = actions.lookup(&md->in_port);
+  u16 in_port_index = md->in_port;
+  struct action *x = actions.lookup(&in_port_index);
   if (!x) {
     pcn_log(ctx, LOG_DEBUG, "No action associated to port %d: dropping packet.",
             md->in_port);


### PR DESCRIPTION
This series of patches aims to reduce the overhead introduced by Polycube.
Following optimizations will be applied:

- [x] In the program receiving a packet on an interface, directly inject the index and possible port of the first program to call, instead of retrieving it from a map. Every time a new porgram/port is attached/connected to the interface the rx program of that interface is re-injected with update parameters.
Commit 9127ad4
- [x] In XDP cubes, directly pass the pointer to `struct pkt_metadata` contained in the `PERCPU_ARRAY_MAP`, instead of copying it to a local structure and then copying it back to the map.
Commit 44d58d2
- [x] Dynamically generate the `pcn_pkt_redirect()` function of standard cubes with a switch-case construct containing the action to perform for each port, instead of relying on a map.
When a packet is directed out of an interface directly call the `bpf_redirect()` helper instead of calling an additional program that performs this task (`ExtIfaceTC::TX_CODE` and `ExtIfaceXDP::TX_CODE`).

Fixes  #300

Here are some numbers that show basic forwarding performance of Polycube (the used program simply receives the packet on an interface, swaps src and dst macs and forwards it on the other interface).
Single core tests run on a Intel Xeon @2.6GHz.
```
Pure XDP   7.07 Mpps
Polycube            CURRENT       OPTIMIZED
XDP_DRV           4.45 Mpps       6.41 Mpps
TC                1.33 Mpps       1.66 Mpps