### PR TITLE
Fix Missing `bc` command

### DIFF
--- a/scripts/pre-requirements.sh
+++ b/scripts/pre-requirements.sh
@@ -8,11 +8,13 @@ mkdir -p $WORKDIR
 $SUDO apt update
 $SUDO bash -c "apt install --allow-unauthenticated -y wget gnupg2 software-properties-common"
 
-os_limit="20.04"
-os_version=`cat /etc/os-release | grep -Po 'VERSION_ID="\K.*?(?=")'`
+# Release in which has been natively introduced support for golang-go (Ubuntu >= 20.04)
+os_limit_major="20"
+os_limit_minor="04"
+read -r os_major os_minor<<<$(grep -Po 'VERSION_ID="\K.*?(?=")' /etc/os-release | sed 's/\./ /g')
 
-# golang v1.12 still not available in repos for Ubuntu versions < 20.04
-if (( $(echo "$os_version < $os_limit" | bc -l) ))
+# Checking whether the major release is lower or the minor
+if  (( os_major < os_limit_major || ( os_major == os_limit_major && os_minor < os_limit_minor ) ))
 then
   $SUDO add-apt-repository ppa:longsleep/golang-backports -y || true
 fi


### PR DESCRIPTION
This commit fixes a previous PR I made where, to check the OS versions, I used `bc` from command line assuming that it existed. It turned out that this caused problem, so now I am proposing to add this command in the installation process

Signed-off-by: Simone Magnani <simonemagnani.96@gmail.com>