### PR TITLE
Dynmon enhancement - Key export feature

### DIFF
--- a/src/services/pcn-dynmon/src/Dynmon.cpp
+++ b/src/services/pcn-dynmon/src/Dynmon.cpp
@@ -105,6 +105,7 @@ std::vector<std::shared_ptr<Metrics>> Dynmon::getMetricsList() {
           Metrics(*this, it->getName(), value.dump(), Utils::genTimestampMicroSeconds());
       metrics.push_back(std::make_shared<Metrics>(metric));
     } catch (const std::exception &ex) {
+      logger()->warn("{0}",ex.what());
       logger()->warn("Unable to read {0} map", it->getMapName());
     }
   }

--- a/src/services/pcn-dynmon/test/test2.sh
+++ b/src/services/pcn-dynmon/test/test2.sh
@@ -1,0 +1,86 @@
+#! /bin/bash
+
+# include helper.bash file: used to provide some common function across testing scripts
+source "${BASH_SOURCE%/*}/helpers.bash"
+
+# function cleanup: is invoked each time script exit (with or without errors)
+# please remember to cleanup all entities previously created:
+# namespaces, veth, cubes, ..
+function cleanup {
+  set +e
+  polycubectl dynmon del dm
+  delete_veth 2
+}
+trap cleanup EXIT
+
+# Enable verbose output
+set -x
+
+# Makes the script exit, at first error
+# Errors are thrown by commands returning not 0 value
+set -e
+
+DIR=$(dirname "$0")
+
+TYPE="TC"
+
+if [ -n "$1" ]; then
+  TYPE=$1
+fi
+
+# helper.bash function, creates namespaces and veth connected to them
+create_veth 2
+
+# create instance of service dynmon
+polycubectl dynmon add dm type=$TYPE
+polycubectl dm show
+
+# attaching the monitor to veth1
+polycubectl attach dm veth1
+
+
+
+# injecting a dataplane configuration
+curl -H "Content-Type: application/json" "localhost:9000/polycube/v1/dynmon/dm/dataplane" --upload-file $DIR/test_map_extraction.json
+polycubectl dm show
+
+set +e
+sudo ip netns exec ns1 ping 10.0.0.2 -c 1 -w 1
+set -e
+
+polycubectl dm metrics show
+
+expected_sh='[{"key":{"saddr":1,"daddr":2,"sport":11,"dport":22,"proto":0},"value":0}]'
+expected_sa='[{"timestamp":1010,"length":1010}]'
+expected_shh='Unhandled Map Type 13 extraction.'
+simple_hash_value=$(polycubectl dm metrics SIMPLE_HASH value show)
+simple_array_value=$(polycubectl dm metrics SIMPLE_ARRAY value show)
+set +e
+simple_hash_hash_value=$(polycubectl dm metrics SIMPLE_HASH_OF_HASH value show)
+set -e
+
+if [ "$simple_array_value" != "$expected_sa" ]
+then
+    echo "SIMPLE_ARRAY extraction failed"
+    echo "Expected: $expected_sa"
+    echo "Got: $simple_array_value"
+    exit 1
+fi
+
+if [ "$simple_hash_value" != "$expected_sh" ]
+then
+    echo "SIMPLE_HASH extraction failed"
+    echo "Expected: $expected_sh"
+    echo "Got: $simple_hash_value"
+    exit 1
+fi
+
+if [ "$simple_hash_hash_value" != "$expected_shh" ]
+then
+    echo "SIMPLE_HASH_OF_HASH extraction failed"
+    echo "Expected: $expected_shh"
+    echo "Got: $simple_hash_hash_value"
+    exit 1
+fi
+
+echo "All tests passed!"

--- a/src/services/pcn-dynmon/test/test_map_extraction.json
+++ b/src/services/pcn-dynmon/test/test_map_extraction.json
@@ -1,0 +1,33 @@
+{
+  "name": "Feature extractor probe",
+  "code": "#define IPPROTO_ICMP 1\n\nstruct features {\n    uint64_t timestamp;\n    uint16_t length;\n} __attribute__((packed));\n\nstruct session_key {\n    __be32 saddr;\n    __be32 daddr;\n    __be16 sport;\n    __be16 dport;\n    __u8   proto;\n} __attribute__((packed));\n\n\nBPF_ARRAY(SIMPLE_ARRAY, struct features, 1);\nBPF_TABLE(\"hash\", struct session_key, int, SIMPLE_HASH, 1);\nBPF_HASH_OF_MAPS(SIMPLE_HASH_OF_HASH, \"SIMPLE_ARRAY\", 1);\n\nstatic __always_inline int handle_rx(struct CTXTYPE *ctx, struct pkt_metadata *md) {\n  struct session_key key = {.saddr=1, .daddr=2, .sport=11, .dport=22, .proto=0};\n  int i = 0;\n  int *value = SIMPLE_HASH.lookup_or_try_init(&key, &i);\n  \n  struct features newVal = {.timestamp=1010, .length=1010};\n  SIMPLE_ARRAY.update(&i, &newVal);\n\n  return RX_OK;\n}\n",
+  "metrics": [
+    {
+      "name": "SIMPLE_HASH_OF_HASH",
+      "map-name": "SIMPLE_HASH_OF_HASH",
+      "open-metrics-metadata": {
+        "help": "This metric is a simple hash of hash map.",
+        "type": "counter",
+        "labels": []
+      }
+    },
+    {
+      "name": "SIMPLE_ARRAY",
+      "map-name": "SIMPLE_ARRAY",
+      "open-metrics-metadata": {
+        "help": "This metric is a simple array.",
+        "type": "counter",
+        "labels": []
+      }
+    },
+    {
+      "name": "SIMPLE_HASH",
+      "map-name": "SIMPLE_HASH",
+      "open-metrics-metadata": {
+        "help": "This is a simple hash map.",
+        "type": "counter",
+        "labels": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR addresses the 2nd point discussed in polycube-network#291.
It has been introduced the key extraction, meaning that if the bpf map is a
key-value type one, not only the value is exported, but also the associated key.

Still, for map-in-map types there is not full support yet, due to many problem related to
the map info retrieval.

Signed-off-by: Simone Magnani <simonemagnani.96@gmail.com>