### PR TITLE
Fixing ParentResource::IsMandatory return value

### DIFF
--- a/src/polycubed/src/server/Resources/Body/ParentResource.cpp
+++ b/src/polycubed/src/server/Resources/Body/ParentResource.cpp
@@ -136,7 +136,7 @@ void ParentResource::AddChild(std::shared_ptr<Resource> &&child) {
 
 bool ParentResource::IsMandatory() const {
   if (container_presence_)
-    return true;
+    return false;
   if (rpc_action_)
     return false;
   return std::end(children_) !=


### PR DESCRIPTION
As indicated in [RFC6020](https://tools.ietf.org/html/rfc6020#section-3.1), a Yang container is mandatory only when the "presence" statement is NOT present and it has at least one mandatory node as a child.

This PR fixes the return value of the `ParentResource::IsMandatory()` which currently returns `true` when the presence statement is present.