### PR TITLE
Introduced Queue/Stack both in Polycube and in Dynmon

### DIFF
--- a/src/libs/polycube/include/polycube/common.h
+++ b/src/libs/polycube/include/polycube/common.h
@@ -19,6 +19,11 @@
 #include "spdlog/spdlog.h"
 #include <string>
 
+#include <sys/utsname.h>
+
+#define QUEUE_STACK_KERNEL_RELEASE "5.0.0"
+#define BATCH_KERNEL_RELEASE "5.6.0"
+
 namespace polycube {
 
 namespace service {
@@ -60,5 +65,9 @@ std::string port_status_to_string(PortStatus status);
 PortStatus string_to_port_status(const std::string &status);
 
 size_t get_possible_cpu_count();
+
+std::string get_kernel_release();
+
+bool compare_kernel_release(std::string &current, const std::string& required);
 
 }  // namespace polycube

--- a/src/libs/polycube/include/polycube/services/base_cube.h
+++ b/src/libs/polycube/include/polycube/services/base_cube.h
@@ -72,6 +72,11 @@ class BaseCube {
       const std::string &table_name, int index = 0,
       ProgramType type = ProgramType::INGRESS);
 
+  template <class ValueType>
+  QueueStackTable<ValueType> get_queuestack_table(
+      const std::string &table_name, int index = 0,
+      ProgramType type = ProgramType::INGRESS);
+
   const ebpf::TableDesc &get_table_desc(const std::string &table_name, int index,
                                      ProgramType type);
                                      
@@ -135,6 +140,14 @@ PercpuHashTable<KeyType, ValueType> BaseCube::get_percpuhash_table(
   int fd = get_table_fd(table_name, index, type);
   return PercpuHashTable<KeyType, ValueType>(&fd);
 }
+
+template <class ValueType>
+QueueStackTable<ValueType> BaseCube::get_queuestack_table(
+    const std::string &table_name, int index, ProgramType type) {
+  int fd = get_table_fd(table_name, index, type);
+  return QueueStackTable<ValueType>(&fd);
+}
+
 
 }  // namespace service
 }  // namespace polycube

--- a/src/libs/polycube/include/polycube/services/table.h
+++ b/src/libs/polycube/include/polycube/services/table.h
@@ -20,6 +20,8 @@
 #include <string>
 #include <vector>
 
+#include <linux/version.h>
+
 #include "polycube/common.h"
 
 namespace polycube {
@@ -40,6 +42,9 @@ class RawTable {
 
   int first(void *key);
   int next(const void *key, void *next);
+
+  int pop(void *value);
+  int push(const void *value);
 
   // protected:
   RawTable(void *op);
@@ -229,6 +234,26 @@ class PercpuHashTable : protected RawTable {
   // private:
   PercpuHashTable(void *op) : RawTable(op), ncpus_(get_possible_cpu_count()){};
   unsigned int ncpus_;
+};
+
+template <class ValueType>
+class QueueStackTable : protected RawTable {
+
+ public:
+  QueueStackTable() : RawTable(){};
+  ~QueueStackTable(){};
+
+  ValueType pop() {
+    ValueType t;
+    RawTable::pop(&t);
+    return t;
+  };
+
+  void push(const ValueType &value) {
+    RawTable::push(&value);
+  }
+
+  QueueStackTable(void *op) : RawTable(op){};
 };
 
 }  // namespace service

--- a/src/libs/polycube/src/common.cpp
+++ b/src/libs/polycube/src/common.cpp
@@ -108,4 +108,38 @@ PortStatus string_to_port_status(const std::string &status) {
   }
 }
 
+std::string get_kernel_release() {
+  struct utsname buffer = {};
+  if (uname(&buffer) != 0)
+    throw std::runtime_error("Unable to execute `uname` command");
+  return buffer.release;
+}
+
+bool compare_kernel_release(std::string &current, const std::string& required) {
+  //  Variables to store numeric parts of the release
+  int vnum1 = 0, vnum2 = 0;
+
+  //  Loop until both string are processed. At each loop increase indexes, reset
+  //  numeric parts and go on parsing
+  for (int i=0,j=0; (i<current.length() && j<required.length()); i++, j++, vnum1=vnum2=0){
+    //  storing numeric part of current version in vnum1
+    while (i < current.length() && isdigit(current[i])) {
+      vnum1 = vnum1 * 10 + (current[i] - '0');
+      i++;
+    }
+
+    //  storing numeric part of required version in vnum2
+    while (j < required.length() && isdigit(required[j])) {
+      vnum2 = vnum2 * 10 + (required[j] - '0');
+      j++;
+    }
+
+    if (vnum1 > vnum2)
+      return true;
+    if (vnum2 > vnum1)
+      return false;
+  }
+  return true;
+}
+
 }  // namespace polycube

--- a/src/services/pcn-dynmon/src/MapExtractor.h
+++ b/src/services/pcn-dynmon/src/MapExtractor.h
@@ -73,11 +73,12 @@ class MapExtractor {
    * @param[table] a RawTable object corresponding to the eBPF table
    * @param[key_size] the size of the table keys
    * @param[value_size] the size of the table values
+   * @param[isQueueStack] indicates whether the map has to be treated like a Queue/Stack
    *
    * @returns a vector of MapEntry objects
    */
   static std::vector<std::shared_ptr<MapEntry>> getMapEntries(
-      RawTable table, size_t key_size, size_t value_size);
+      RawTable table, size_t key_size, size_t value_size, bool isQueueStack = false);
 
   /**
    * Recursive method which identifies the type of an object


### PR DESCRIPTION
In this PR I propose a possible solution which introduces the new bpf map types
in Polycube. I've also enhanced Dynmon in order to exports this maps data.

These maps introduce a new level of abstraction which is different that the previous ones, since the only admitted operation on Queues/Stacks are PUSH/POP (and PEEK but that's not the point). The fact is that the actua RawTable allows only to perform lookup, but this is not working with new data types.

My solution is the following:

* Added raw push/pop methods to RawTable
* Added utility functions to check the current kernel version, in order to disable at runtime these operations if not supported
* Added a QueueStackTable class, which is a template class extension of a RawTable (like all the other tables in Polycube)

I would have preferred making a RawTable class smarter, meaning that if a GET is called it check whether it has to perform a simple lookup or a pop, depending on the underlying map type. However, I don't know if you would like a solution like that, since it will introduce more "intelligence" to a Raw class.

Both pop/push operations has been introduced in the RawTable, but of course they would not work if the underlying table is not a queue/stack. This is up to the consumer to call the right method, if it is using such table. This addition allows Dynmon to interact with a RawTable, no matter its type, since it has to check a runtime both table and key type, and creating a specific table depending on the key type (int/struct ...) would not only make the code less comprehensible, but it would also be way bigger in size. 

Still not ready to be merged, I need to think of possible completions and features to introduce.

Signed-off-by: Simone Magnani <simonemagnani.96@gmail.com>