### PR TITLE
Adding Federico Parola for PR review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,10 @@
 # @polycube-network/pcn-maintainers will be requested for
 # review when someone opens a pull request.
 *       @polycube-network/pcn-maintainers
+
+# PR review based on matches
+/src/             @FedeParola
+/Documentation/   @FedeParola
+/cmake/           @FedeParola
+/scripts/         @FedeParola
+/tests/           @FedeParola


### PR DESCRIPTION
Federico Parola to be added for the PR reviews as per requested by @frisso 
This list can be further extended.