### PR TITLE
Bcc-static linked at compile time for Polycubed already includes the …

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@ include_directories(${CMAKE_SOURCE_DIR}/src/libs/bcc/src/cc/libbpf/include/uapi)
 
 option(INSTALL_CLI "installs the polycube CLI" ON)
 option(ENABLE_PCN_IPTABLES "enables the pcn-iptables" OFF)
+option(ENABLE_LLVM_SHARED "Enable linking LLVM as a shared library" ON)
 
 add_subdirectory(components)
 add_subdirectory(libs)


### PR DESCRIPTION
…LLVM static library.At runtime polycubed links clang again, clang links the dynamic library of LLVM, causing LLVM to report error: "Option XXXXXX registered more than once"

issue:https://github.com/polycube-network/polycube/issues/335

I can't think of a better way. Do you have any better Suggestions?