### PR TITLE
Fix map reuse when reloading TC egress program of XDP cubes

### DIFF
--- a/src/polycubed/src/cube_xdp.cpp
+++ b/src/polycubed/src/cube_xdp.cpp
@@ -86,7 +86,7 @@ void CubeXDP::reload(const std::string &code, int index, ProgramType type) {
         std::unique_lock<std::mutex> bcc_guard(bcc_mutex);
         std::unique_ptr<ebpf::BPF> new_bpf_program = std::unique_ptr<ebpf::BPF>(
             new ebpf::BPF(0, nullptr, false, name_, false,
-                          egress_programs_tc_.at(index).get()));
+                          egress_programs_.at(index).get()));
 
         bcc_guard.unlock();
         compileTC(*new_bpf_program, code);

--- a/src/polycubed/src/transparent_cube_xdp.cpp
+++ b/src/polycubed/src/transparent_cube_xdp.cpp
@@ -96,7 +96,7 @@ void TransparentCubeXDP::reload(const std::string &code, int index,
         std::unique_lock<std::mutex> bcc_guard(bcc_mutex);
         std::unique_ptr<ebpf::BPF> new_bpf_program = std::unique_ptr<ebpf::BPF>(
             new ebpf::BPF(0, nullptr, false, name_, false,
-                          egress_programs_tc_.at(index).get()));
+                          egress_programs_.at(index).get()));
 
         bcc_guard.unlock();
         TransparentCubeTC::do_compile(get_id(), egress_next_tc_,


### PR DESCRIPTION
There is a bug when reloading a program in the egress path of a XDP cube: XDP egress is emulated with two programs, a TC one to handle packets coming from the stack and a XDP one to handle packets coming from other XDP cubes. This programs should share the same maps in order to behave as one. There is a bug that causes these maps to differ after a reload. This patch fixes the problem.