### PR TITLE
A possible solution to fix bug #352

### DIFF
--- a/src/services/pcn-nat/src/Nat.cpp
+++ b/src/services/pcn-nat/src/Nat.cpp
@@ -141,6 +141,7 @@ std::shared_ptr<Rule> Nat::getRule() {
 }
 
 void Nat::addRule(const RuleJsonObject &value) {
+  logger()->info("Adding rule");
   rule_ = std::make_shared<Rule>(*this, value);
 }
 
@@ -150,7 +151,11 @@ void Nat::replaceRule(const RuleJsonObject &conf) {
 }
 
 void Nat::delRule() {
-  rule_ = nullptr;
+  rule_ = nullptr; //In this way we can call the destroyers of the rules Snat, Dnat, Port-Forwarding
+  // We need an "empty" rule_ like the one created at initialization in the constructor. 
+  // Otherwise there is an error in the display of the nat after the deletion. As in issue #352
+  RuleJsonObject empty_rule;
+  rule_ = std::make_shared<Rule>(*this, empty_rule); 
 }
 
 std::shared_ptr<NattingTable> Nat::getNattingTable(


### PR DESCRIPTION
This PR fixes bug #352 

If you reset the rule_ variable (putting it to nullptr) in the delRule method, a subsequent command like ` polycubectl nat1 show` ends up calling the toJsonObject method to construct the JSON to be displayed to the user. Here we have this statement conf.setRule(getRule ()->toJsonObject ()); which, however, calls the toJsonObject() on a nullptr variable which causes the error.

The solution was to leave the deletion of rule_ in the delRule method in such a way as to also delete all the other rules (snat, dnat, port-forwarding) and then do as in the constructor, creating an "empty" rule_.

This solution also works for the case in which no rules have been added to the NAT and a user tries to do ` polycubectl nat1 rule del`.

Here there is an example:
```
netgroup@giuseppe:~$ polycubectl nat nat1
netgroup@giuseppe:~$ polycubectl nat1 show
name: nat1
uuid: 3e4c0102-a77a-47d8-a536-8c78178cea3e
service-name: nat
type: TC
loglevel: INFO
parent: 
rule:
 snat:
 masquerade:
  enabled: false
 dnat:
 port-forwarding:

netgroup@giuseppe:~$ polycubectl nat1 rule del
netgroup@giuseppe:~$ polycubectl nat1 show
name: nat1
uuid: 3e4c0102-a77a-47d8-a536-8c78178cea3e
service-name: nat
type: TC
loglevel: INFO
parent: 
rule:
 snat:
 masquerade:
  enabled: false
 dnat:
 port-forwarding:
 
netgroup@giuseppe:~$ polycubectl nat1 rule snat append internal-net=10.0.0.0/24 external-ip=1.2.3.5
id: 0

netgroup@giuseppe:~$ polycubectl nat1 show
name: nat1
uuid: 3e4c0102-a77a-47d8-a536-8c78178cea3e
service-name: nat
type: TC
loglevel: INFO
parent: 
rule:
 snat:

  entry:
   id  internal-net  external-ip
   0   10.0.0.0/24   1.2.3.5/32
 masquerade:
  enabled: false
 dnat:
 port-forwarding:

netgroup@giuseppe:~$ polycubectl nat1 rule del
netgroup@giuseppe:~$ polycubectl nat1 show
name: nat1
uuid: 3e4c0102-a77a-47d8-a536-8c78178cea3e
service-name: nat
type: TC
loglevel: INFO
parent: 
rule:
 snat:
 masquerade:
  enabled: false
 dnat:
 port-forwarding:
```




As I commented in the Nat.cpp file, I have some doubts about the subscribe but I have done both tests and various tests and everything seems to work.