### PR TITLE
A possible solution to solve bug #350

### DIFF
--- a/src/services/pcn-router/src/Ports.cpp
+++ b/src/services/pcn-router/src/Ports.cpp
@@ -237,6 +237,10 @@ std::shared_ptr<PortsSecondaryip> Ports::getSecondaryip(const std::string &ip) {
     if (p.getIp() == ip)
       return std::make_shared<PortsSecondaryip>(p);
   }
+  // It can happen in 3 cases: the port has no IP, 
+  // the port has secondaryip but not the one sought, the port has 0 secondaryip
+  throw std::runtime_error(
+        "Address does not exist or it is not a secondary address or the port has no ip address");
 }
 
 std::vector<std::shared_ptr<PortsSecondaryip>> Ports::getSecondaryipList() {


### PR DESCRIPTION
This PR fixes bug #350  

The error was that before deleting the secondaryip, (by calling the `delete_router_ports_secondaryip_by_id` method which calls `delSecondaryip`), the method `read_router_ports_secondaryip_by_id` was called which inside calls `getSecondaryip(ip)`. Here  the case in which a secondaryip was not present was not handled (both because does not exist or because the port has no secondaryip or even the main ip address).

In the proposed solution, the `getSecondaryip` method returns nullptr if it does not find the secondaryip and then in the `read_router_ports_secondaryip_by_id method` an empty `PortsSecondaryipJsonObject` is returned; doing so will call the `delete_router_ports_secondaryip_by_id` (like a normal execution) method which will handle the error displaying it to the user.


Here there is an example:
```
netgroup@giuseppe:~$ polycubectl router r1
netgroup@giuseppe:~$ polycubectl r1 ports p1
netgroup@giuseppe:~$ polycubectl r1 ports p1 secondaryip del 1.1.1.3/24
Address does not exist (or it is not a secondary address)

netgroup@giuseppe:~$ polycubectl r1 ports p1 set ip=1.1.1.1/24
netgroup@giuseppe:~$ polycubectl r1 ports p1 secondaryip del 1.1.1.3/24
Address does not exist (or it is not a secondary address)

netgroup@giuseppe:~$ polycubectl r1 ports p1 secondaryip add 1.1.1.100/24
netgroup@giuseppe:~$ polycubectl r1 ports p1 secondaryip add 1.1.1.99/24
netgroup@giuseppe:~$ polycubectl r1 ports p1 secondaryip del  1.1.1.99/24
netgroup@giuseppe:~$polycubectl r1 ports p1 secondaryip del  1.1.1.99/24
Address does not exist (or it is not a secondary address)
```
