### PR TITLE
Adding golang to the list of packages to be installed

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,6 +23,13 @@ function success_message {
   set +x
   echo
   echo 'Installation completed successfully'
+  echo
+  echo 'You can now start the polycube daemon:'
+  echo '  manually:     sudo polycubed &'
+  echo '  with systemd: sudo systemctl start polycubed'
+  echo 'and then interact with it using the Polycube command line:'
+  echo '  polycubectl -h'
+  echo
   exit 0
 }
 trap error_message ERR

--- a/scripts/pre-requirements.sh
+++ b/scripts/pre-requirements.sh
@@ -39,10 +39,12 @@ PACKAGES+=" libpcap-dev" # needed for packetcapture filter
 
 if ! command -v go &> /dev/null
 then
-   # Checking whether the major release is lower or the minor
+  # Go is not available, so let's add to the list of required packages
+  PACKAGES+=" golang-go" # needed for polycubectl and pcn-k8s
+  
+  # Checking whether the major release is lower or the minor
   if  (( os_major < os_limit_major || ( os_major == os_limit_major && os_minor < os_limit_minor ) ))
   then
-    PACKAGES+=" golang-go" # needed for polycubectl and pcn-k8s
     $SUDO add-apt-repository ppa:longsleep/golang-backports -y || true
   fi
 fi


### PR DESCRIPTION
Currently it was added only if OS< 20.04; this is wrong, golang has to be always installed; what's different is that in pre-20.04 you have to add explicitely the package repository.