### PR TITLE
Update NAT examples to use transparent version of the nat

### DIFF
--- a/src/services/pcn-nat/test/examples/example1.sh
+++ b/src/services/pcn-nat/test/examples/example1.sh
@@ -2,12 +2,14 @@
 
 #         TOPOLOGY
 #
-#                              +-----------+                 +-----------+
-#      veth1 (10.0.1.1)--------|     r1    |-----------------|    nat1   |------- veth2 (10.0.2.1)
-#                            ^ +-----------+  ^            ^ +-----------+  ^
-#                            |                |            |                |
-#                          to_veth1        to_nat1  to_r1 (INTERNAL)    to_veth2 (EXTERNAL)
-#
+#       ns1      |                         default ns                       |      ns2
+#                |                                                          |
+#  +----------+  |  +------------+                          +------------+  |  +----------+
+#  |  veth1_  |  |  |   veth1    |  +-----------+--------+  |   veth2    |  |  |  veth2_  |
+#  | 10.0.1.1 |-----| 10.0.1.254 |--| router r1 | nat n1 |--| 10.0.2.254 |-----| 10.0.2.1 |
+#  +----------+  |  +------------+  +-----------+--------+  +------------+  |  +----------+
+#                |                  ^           ^                           |
+#                |           r1:to_veth1      r1:to_veth2                   |
 
 # MASQUERADE EXAMPLE
 
@@ -16,40 +18,40 @@ source "../helpers.bash"
 function cleanup {
     set +e
     polycubectl router del r1
-    polycubectl nat del nat1
+    polycubectl nat del n1
 
     delete_veth 2
 }
 trap cleanup EXIT
 
-veth1_ip=10.0.1.1
-veth2_ip=10.0.2.1
-to_nat_ip=10.0.2.254
-to_veth1_ip=10.0.1.254
+ip_veth1_=10.0.1.1
+ip_veth2_=10.0.2.1
+
+# When directly connected, the port of the router and the interface of the host
+# behave as a unique entity, sharing ip and mac addresses
+ip_veth1=10.0.1.254
+ip_to_veth1=$ip_veth1
+ip_veth2=10.0.2.254
+ip_to_veth2=$ip_veth2
 
 set -x
 
 # Create namespaces and veths
 create_veth_net 2
 
-# Configure NAT and router
-polycubectl nat add nat1
+# Configure router
 polycubectl router add r1
+polycubectl router r1 ports add to_veth1 ip=$ip_to_veth1/24 peer=veth1
+polycubectl router r1 ports add to_veth2 ip=$ip_to_veth2/24 peer=veth2
 
-polycubectl router r1 ports add to_veth1 ip=$to_veth1_ip/24
-polycubectl router r1 ports to_veth1 set peer=veth1
-polycubectl router r1 ports add to_nat1 ip=$to_nat_ip/24
-
-polycubectl nat1 ports add to_r1 type=INTERNAL
-polycubectl connect nat1:to_r1 r1:to_nat1
-
-polycubectl nat1 ports add to_veth2 type=EXTERNAL ip=$to_nat_ip
-polycubectl connect nat1:to_veth2 veth2
+# Configure NAT
+polycubectl nat add n1
+polycubectl attach n1 r1:to_veth2
 
 # Enable masquerade
-polycubectl nat1 rule masquerade enable
+polycubectl n1 rule masquerade enable
 
-sudo ip netns exec ns1 ping $veth2_ip -c 3
+sudo ip netns exec ns1 ping $ip_veth2_ -c 3
 
 # Show natting table
-polycubectl nat1 natting-table show
+polycubectl n1 natting-table show

--- a/src/services/pcn-nat/test/examples/example2.sh
+++ b/src/services/pcn-nat/test/examples/example2.sh
@@ -2,12 +2,14 @@
 
 #         TOPOLOGY
 #
-#                              +-----------+                 +-----------+
-#      veth1 (10.0.1.1)--------|     r1    |-----------------|    nat1   |------- veth2 (10.0.2.1)
-#                            ^ +-----------+  ^            ^ +-----------+  ^
-#                            |                |            |                |
-#                          to_veth1        to_nat1  to_r1 (INTERNAL)    to_veth2 (EXTERNAL)
-#
+#       ns1      |                         default ns                       |      ns2
+#                |                                                          |
+#  +----------+  |  +------------+                          +------------+  |  +----------+
+#  |  veth1_  |  |  |   veth1    |  +-----------+--------+  |   veth2    |  |  |  veth2_  |
+#  | 10.0.1.1 |-----| 10.0.1.254 |--| router r1 | nat n1 |--| 10.0.2.254 |-----| 10.0.2.1 |
+#  +----------+  |  +------------+  +-----------+--------+  +------------+  |  +----------+
+#                |                  ^           ^                           |
+#                |           r1:to_veth1      r1:to_veth2                   |
 
 # SOURCE NAT EXAMPLE
 
@@ -16,43 +18,43 @@ source "../helpers.bash"
 function cleanup {
     set +e
     polycubectl router del r1
-    polycubectl nat del nat1
+    polycubectl nat del n1
 
     delete_veth 2
 }
 trap cleanup EXIT
 
-veth1_ip=10.0.1.1
-veth2_ip=10.0.2.1
-to_nat_ip=10.0.2.254
-to_veth1_ip=10.0.1.254
+ip_veth1_=10.0.1.1
+ip_veth2_=10.0.2.1
+
+# When directly connected, the port of the router and the interface of the host
+# behave as a unique entity, sharing ip and mac addresses
+ip_veth1=10.0.1.254
+ip_to_veth1=$ip_veth1
+ip_veth2=10.0.2.254
+ip_to_veth2=$ip_veth2
 
 set -x
 
 # Create namespaces and veths
 create_veth_net 2
 
-# Configure NAT and router
-polycubectl nat add nat1
+# Configure router
 polycubectl router add r1
+polycubectl router r1 ports add to_veth1 ip=$ip_to_veth1/24 peer=veth1
+polycubectl router r1 ports add to_veth2 ip=$ip_to_veth2/24 peer=veth2
 
-polycubectl router r1 ports add to_veth1 ip=$to_veth1_ip/24
-polycubectl router r1 ports to_veth1 set peer=veth1
-polycubectl router r1 ports add to_nat1 ip=$to_nat_ip/24
-
-polycubectl nat1 ports add to_r1 type=INTERNAL
-polycubectl connect nat1:to_r1 r1:to_nat1
-
-polycubectl nat1 ports add to_veth2 type=EXTERNAL ip=$to_nat_ip
-polycubectl connect nat1:to_veth2 veth2
+# Configure NAT
+polycubectl nat add n1
+polycubectl attach n1 r1:to_veth2
 
 # Add a matching rule
-polycubectl nat1 rule snat append internal-net=10.0.1.0/24 external-ip=$to_nat_ip
+polycubectl n1 rule snat append internal-net=10.0.1.0/24 external-ip=$ip_veth2
 
 # Add a non matching rule
-polycubectl nat1 rule snat append internal-net=10.0.2.0/24 external-ip=0.0.0.0
+polycubectl n1 rule snat append internal-net=10.0.2.0/24 external-ip=0.0.0.0
 
-sudo ip netns exec ns1 ping $veth2_ip -c 3
+sudo ip netns exec ns1 ping $ip_veth2_ -c 3
 
 # Show the natting table
-polycubectl nat1 natting-table show
+polycubectl n1 natting-table show

--- a/src/services/pcn-nat/test/examples/example3.sh
+++ b/src/services/pcn-nat/test/examples/example3.sh
@@ -2,12 +2,14 @@
 
 #         TOPOLOGY
 #
-#                              +-----------+                 +-----------+
-#      veth1 (10.0.1.1)--------|     r1    |-----------------|    nat1   |------- veth2 (10.0.2.1)
-#                            ^ +-----------+  ^            ^ +-----------+  ^
-#                            |                |            |                |
-#                          to_veth1        to_nat1  to_r1 (INTERNAL)    to_veth2 (EXTERNAL)
-#
+#       ns1      |                         default ns                       |      ns2
+#                |                                                          |
+#  +----------+  |  +------------+                          +------------+  |  +----------+
+#  |  veth1_  |  |  |   veth1    |  +-----------+--------+  |   veth2    |  |  |  veth2_  |
+#  | 10.0.1.1 |-----| 10.0.1.254 |--| router r1 | nat n1 |--| 10.0.2.254 |-----| 10.0.2.1 |
+#  +----------+  |  +------------+  +-----------+--------+  +------------+  |  +----------+
+#                |                  ^           ^                           |
+#                |           r1:to_veth1      r1:to_veth2                   |
 
 # DESTINATION NAT EXAMPLE
 
@@ -16,17 +18,23 @@ source "../helpers.bash"
 function cleanup {
     set +e
     polycubectl router del r1
-    polycubectl nat del nat1
+    polycubectl nat del n1
 
     delete_veth 2
     sudo pkill -SIGTERM netcat
 }
 trap cleanup EXIT
 
-veth1_ip=10.0.1.1
-veth2_ip=10.0.2.1
-to_nat_ip=10.0.2.254
-to_veth1_ip=10.0.1.254
+ip_veth1_=10.0.1.1
+ip_veth2_=10.0.2.1
+
+# When directly connected, the port of the router and the interface of the host
+# behave as a unique entity, sharing ip and mac addresses
+ip_veth1=10.0.1.254
+ip_to_veth1=$ip_veth1
+ip_veth2=10.0.2.254
+ip_to_veth2=$ip_veth2
+
 missing_ip=10.0.3.1
 
 set -x
@@ -34,28 +42,23 @@ set -x
 # Create namespaces and veths
 create_veth_net 2
 
-# Configure NAT and router
-polycubectl nat add nat1
+# Configure router
 polycubectl router add r1
+polycubectl router r1 ports add to_veth1 ip=$ip_to_veth1/24 peer=veth1
+polycubectl router r1 ports add to_veth2 ip=$ip_to_veth2/24 peer=veth2
 
-polycubectl router r1 ports add to_veth1 ip=$to_veth1_ip/24
-polycubectl router r1 ports to_veth1 set peer=veth1
-polycubectl router r1 ports add to_nat1 ip=$to_nat_ip/24
-
-polycubectl nat1 ports add to_r1 type=INTERNAL
-polycubectl connect nat1:to_r1 r1:to_nat1
-
-polycubectl nat1 ports add to_veth2 type=EXTERNAL ip=$to_nat_ip
-polycubectl connect nat1:to_veth2 veth2
+# Configure NAT
+polycubectl nat add n1
+polycubectl attach n1 r1:to_veth2
 
 # Verify that PING does not work before setting the rule
 test_fail sudo ip netns exec ns2 ping $missing_ip -c 3
 
 # Add the rule
-polycubectl nat1 rule dnat append external-ip=$missing_ip internal-ip=$veth1_ip
+polycubectl n1 rule dnat append external-ip=$missing_ip internal-ip=$ip_veth1_
 
 # Verify that PING now works
 sudo ip netns exec ns2 ping $missing_ip -c 3
 
 # Show natting table
-polycubectl nat1 natting-table show
+polycubectl n1 natting-table show

--- a/src/services/pcn-nat/test/examples/example4.sh
+++ b/src/services/pcn-nat/test/examples/example4.sh
@@ -2,12 +2,14 @@
 
 #         TOPOLOGY
 #
-#                              +-----------+                 +-----------+
-#      veth1 (10.0.1.1)--------|     r1    |-----------------|    nat1   |------- veth2 (10.0.2.1)
-#                            ^ +-----------+  ^            ^ +-----------+  ^
-#                            |                |            |                |
-#                          to_veth1        to_nat1  to_r1 (INTERNAL)    to_veth2 (EXTERNAL)
-#
+#       ns1      |                         default ns                       |      ns2
+#                |                                                          |
+#  +----------+  |  +------------+                          +------------+  |  +----------+
+#  |  veth1_  |  |  |   veth1    |  +-----------+--------+  |   veth2    |  |  |  veth2_  |
+#  | 10.0.1.1 |-----| 10.0.1.254 |--| router r1 | nat n1 |--| 10.0.2.254 |-----| 10.0.2.1 |
+#  +----------+  |  +------------+  +-----------+--------+  +------------+  |  +----------+
+#                |                  ^           ^                           |
+#                |           r1:to_veth1      r1:to_veth2                   |
 
 # PORT FORWARDING EXAMPLE
 
@@ -30,17 +32,23 @@ function test_tcp_fail {
 function cleanup {
     set +e
     polycubectl router del r1
-    polycubectl nat del nat1
+    polycubectl nat del n1
 
     delete_veth 2
     sudo pkill -SIGTERM netcat
 }
 trap cleanup EXIT
 
-veth1_ip=10.0.1.1
-veth2_ip=10.0.2.1
-to_nat_ip=10.0.2.254
-to_veth1_ip=10.0.1.254
+ip_veth1_=10.0.1.1
+ip_veth2_=10.0.2.1
+
+# When directly connected, the port of the router and the interface of the host
+# behave as a unique entity, sharing ip and mac addresses
+ip_veth1=10.0.1.254
+ip_to_veth1=$ip_veth1
+ip_veth2=10.0.2.254
+ip_to_veth2=$ip_veth2
+
 missing_ip=10.0.3.1
 tcp_int_port=8080
 tcp_ext_port=80
@@ -50,31 +58,26 @@ set -x
 # Create namespaces and veths
 create_veth_net 2
 
-# Configure NAT and router
-polycubectl nat add nat1
+# Configure router
 polycubectl router add r1
+polycubectl router r1 ports add to_veth1 ip=$ip_to_veth1/24 peer=veth1
+polycubectl router r1 ports add to_veth2 ip=$ip_to_veth2/24 peer=veth2
 
-polycubectl router r1 ports add to_veth1 ip=$to_veth1_ip/24
-polycubectl router r1 ports to_veth1 set peer=veth1
-polycubectl router r1 ports add to_nat1 ip=$to_nat_ip/24
-
-polycubectl nat1 ports add to_r1 type=INTERNAL
-polycubectl connect nat1:to_r1 r1:to_nat1
-
-polycubectl nat1 ports add to_veth2 type=EXTERNAL ip=$to_nat_ip
-polycubectl connect nat1:to_veth2 veth2
+# Configure NAT
+polycubectl nat add n1
+polycubectl attach n1 r1:to_veth2
 
 # Verify that port forwarding does not work before adding the rule
 test_tcp_fail
 
 # Add a generic DNAT rule
-polycubectl nat1 rule dnat append external-ip=$missing_ip internal-ip=$veth1_ip
+polycubectl n1 rule dnat append external-ip=$missing_ip internal-ip=$ip_veth1_
 
 # Add a specific Port Forwarding rule to verify priority
-polycubectl nat1 rule port-forwarding append external-ip=$missing_ip internal-ip=$veth1_ip external-port=$tcp_ext_port internal-port=$tcp_int_port
+polycubectl n1 rule port-forwarding append external-ip=$missing_ip internal-ip=$ip_veth1_ external-port=$tcp_ext_port internal-port=$tcp_int_port
 
 # Verify that Port Forwarding works
 test_tcp
 
 # Show natting table
-polycubectl nat1 natting-table show
+polycubectl n1 natting-table show


### PR DESCRIPTION
Examples were not updated when migrating the NAT to a transparent cube