### PR TITLE
fixed Lbrp::delService handling of service backends deletion

### DIFF
--- a/src/services/pcn-loadbalancer-rp/src/Lbrp.cpp
+++ b/src/services/pcn-loadbalancer-rp/src/Lbrp.cpp
@@ -389,7 +389,7 @@ void Lbrp::delService(const std::string &vip, const uint16_t &vport,
 
   auto service = getService(vip, vport, proto);
 
-  service->removeServiceFromKernelMap();
+  service->delBackendList();
   service_map_.erase(key);
 }
 

--- a/src/services/pcn-loadbalancer-rp/src/Service.cpp
+++ b/src/services/pcn-loadbalancer-rp/src/Service.cpp
@@ -536,7 +536,7 @@ void Service::delBackend(const std::string &ip) {
 }
 
 void Service::delBackendList() {
-  if (service_backends_.size() != 0) {
+  if (!service_backends_.empty()) {
     service_backends_.clear();
     backend_matrix_.clear();
     removeServiceFromKernelMap();


### PR DESCRIPTION
Hi folks! If we try to delete a service without backends, calling directly Service::removeServiceFromKernelMap will generate an exception, so is needed to call Service::delBackendList (that performs a check on the number of backends and performs the cleanup in the right way) in order to correctly delete a service.