### PR TITLE
Fall back to map lookup when cube's redirection code becomes too big

### DIFF
--- a/src/polycubed/src/cube.h
+++ b/src/polycubed/src/cube.h
@@ -78,6 +78,11 @@ class Cube : public BaseCube, public CubeIface {
 
   const std::string get_veth_name_from_index(const int ifindex);
  protected:
+  // Maximum number of ports for which optimized (inlined) redirection code is
+  // generated. Exceeding this number causes the switch-case to be rejected by
+  // the verifier
+  static const int _MAX_OPTIMIZED_PORTS = 17;
+
   static std::string get_wrapper_code();
   uint16_t allocate_port_id();
   void release_port_id(uint16_t id);


### PR DESCRIPTION
The code of the pcn_pkt_redirect() function of standard cubes is dynamically generated to handle redirection to other cubes/interfaces with a switch-case statement.
When there are too many peers however (> 17) this code becomes too big and is rejected by the verfier.
This commit keeps the optimized path for the first peers and adds a fall back table to redirect to other peers.